### PR TITLE
Wrong directory name in quickstart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -445,7 +445,7 @@ Quickstart
 ::
 
     $ git clone https://github.com/seamapi/python.git
-    $ cd pypackage
+    $ cd python
     $ poetry install
 
 Run each command below in a separate terminal window:


### PR DESCRIPTION
## Summary
The Quickstart section tells contributors to `cd pypackage` after cloning, but cloning `https://github.com/seamapi/python.git` creates a directory called `python`, not `pypackage`. This looks like a leftover from a README template. Anyone following the quickstart would hit a "no such file or directory" error immediately.

## How to reproduce
1. Follow the Quickstart in the README
2. Run `git clone https://github.com/seamapi/python.git`
3. Run `cd pypackage` — fails with "no such file or directory"

## Test plan
- Clone the repo fresh and confirm `cd python && poetry install` works without errors