### PR TITLE
test: cover malformed error responses

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,6 +58,9 @@ def recording_server_fixture():
 def recording_server(responses):
     """Serve the given (status, body) responses, repeating the last one.
 
+    A response may also be (status, body, content_type) to override the
+    content type inferred from the body, e.g. to serve malformed JSON.
+
     Yields the endpoint along with the list of requests received so far.
     """
 
@@ -80,7 +83,8 @@ def recording_server(responses):
                 }
             )
 
-            status, payload = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+            response = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+            status, payload, *rest = response
 
             if isinstance(payload, str):
                 content_type = "text/plain"
@@ -88,6 +92,9 @@ def recording_server(responses):
             else:
                 content_type = "application/json"
                 body = json.dumps(payload).encode()
+
+            if rest:
+                content_type = rest[0]
 
             self.send_response(status)
             self.send_header("content-type", content_type)

--- a/test/http_error_test.py
+++ b/test/http_error_test.py
@@ -60,3 +60,50 @@ def test_seam_http_throws_http_error_on_non_standard_response(server):
         seam.devices.list()
 
     assert exc_info.value.response.status_code == 503
+
+
+# The fake cannot produce malformed error responses, so the recording server
+# drives the bodies that must fall through is_api_error_response and raise a
+# plain HTTPError rather than being parsed into a SeamHttpApiError.
+def test_seam_http_raises_http_error_on_non_json_response(recording_server):
+    with recording_server([(500, "Internal Server Error")]) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+        with pytest.raises(niquests.HTTPError) as exc_info:
+            seam.devices.list()
+
+    assert exc_info.value.response.status_code == 500
+
+
+def test_seam_http_raises_http_error_on_malformed_json(recording_server):
+    responses = [(500, "{invalid json", "application/json")]
+
+    with recording_server(responses) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+        with pytest.raises(niquests.HTTPError) as exc_info:
+            seam.devices.list()
+
+    assert exc_info.value.response.status_code == 500
+
+
+def test_seam_http_raises_http_error_on_json_without_error_object(recording_server):
+    with recording_server([(500, {"message": "Some error"})]) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+        with pytest.raises(niquests.HTTPError) as exc_info:
+            seam.devices.list()
+
+    assert exc_info.value.response.status_code == 500
+
+
+def test_seam_http_raises_http_error_on_error_object_without_type_and_message(
+    recording_server,
+):
+    with recording_server([(500, {"error": {"code": 500}})]) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+        with pytest.raises(niquests.HTTPError) as exc_info:
+            seam.devices.list()
+
+    assert exc_info.value.response.status_code == 500


### PR DESCRIPTION
Follow-up to #598. After it merged, I audited the deleted tests against what remains on `main`: nothing was lost — both deleted `test/workspaces` files covered generated route methods, and workspace creation stayed covered in the multi-workspace tests. But the audit surfaced a gap the suite has always had, which the Ruby SDK briefly lost in the sibling PR and is getting restored in seamapi/ruby#538 — so this closes it here too for parity.

## The gap

`SeamHttpClient._handle_error_response` splits error responses in two: standard Seam error bodies become `SeamHttpApiError`, and everything else falls through `is_api_error_response` to `raise_for_status`. Only the first half was covered. The suite never exercised:

- a non-JSON body (`text/plain`)
- malformed JSON served with a JSON content type
- a JSON body without an `error` object
- an `error` object without string `type` and `message` fields

All four now assert a plain `niquests.HTTPError` with the original status, driven by the recording server — the fake cannot produce these responses. The recording server grows an optional third tuple element to override the content type, which is what lets it serve malformed JSON.

Tests only, no SDK changes.

## Verification

```
61 passed in 30.37s
```

`black --check`, `pylint` (10.00/10) clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_011DzapiU8A9NMdyoTybL9xB)_