### PR TITLE
docs: name the page cursor property as Python spells it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Contents
 
   * `Pagination`_
 
-    * `Manually fetch pages with the nextPageCursor`_
+    * `Manually fetch pages with the next_page_cursor`_
 
     * `Resume pagination`_
 
@@ -282,8 +282,8 @@ Pagination
 Some Seam API endpoints that return lists of resources support pagination.
 Use the ``SeamPaginator`` class to fetch and process resources across multiple pages.
 
-Manually fetch pages with the nextPageCursor
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manually fetch pages with the next_page_cursor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 


### PR DESCRIPTION
The pagination heading in the README called the cursor `nextPageCursor`, which is how the JavaScript SDK spells it. This SDK exposes it as `pagination.next_page_cursor` (`seam/resources/pagination.py`), and the example directly under that heading already uses the snake_case name:

```python
if pagination.has_next_page:
    more_devices, _ = paginator.next_page(pagination.next_page_cursor)
```

So the heading named a property that does not exist in this SDK. This renames it to match, and updates the generated table of contents entry that references it.

Turned up while looking at camelCase identifiers in the SDK. Worth noting the API surface itself is consistent — every method and parameter is snake_case, since codegen converts the blueprint names. This was doc text that escaped that conversion.

`uv run rstcheck README.rst` passes, and the table of contents was regenerated with `node generate-readme-toc.js` rather than edited by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpqwDhZmyikGbjmCPqFW2A)_