### PR TITLE
fix: pin the Black target version to the minimum supported Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ module-root = ""
 source-exclude = ["**/*_test.py"]
 wheel-exclude = ["**/*_test.py"]
 
+[tool.black]
+target-version = ["py311"]
+
 [tool.pytest.ini_options]
 norecursedirs = [
     "node_modules"


### PR DESCRIPTION
## Problem

Every `Lint` job on `beta` emits a warning, on all four matrix legs (3.11–3.14):

```
Warning: Python 3.14 cannot parse code formatted for Python 3.15. To fix this: run Black
with Python 3.15, set --target-version to py314, or use --fast to skip the safety check.
Black's safety check verifies equivalence by parsing the AST, which fails when the running
Python is older than the target version.
```

Latest `beta` run: [31718873837](https://github.com/seamapi/python/actions/runs/31718873837). It also reproduces locally via `just lint`.

## Cause

There was no `[tool.black]` section, so Black inferred its target versions from `project.requires-python`. Because that bound is open-ended (`>=3.11`), it expanded to every version Black knows about:

```
$ black --check --verbose seam/__init__.py
target_version: ['py311', 'py312', 'py313', 'py314', 'py315']
```

Black's safety check re-parses its own output with the stdlib `ast` module, using the *highest* target version. No interpreter from 3.11 through 3.14 can produce a 3.15 AST, so the check is skipped and the warning is printed.

## Impact

Formatting was never wrong, and lint was never failing. Black only emits syntax common to *all* of its targets, so it was already formatting for the 3.11 floor. Verified two ways:

- `black --diff --target-version py315 .` and `--target-version py311 .` produce byte-identical output across the repo.
- Black still reformats correctly under the old config (checked against a deliberately unformatted file).

What was actually lost is the AST equivalence check — Black's guard against its own output changing program semantics. That guard was silently off for every lint run.

## Change

```toml
[tool.black]
target-version = ["py311"]
```

Pinning the floor explicitly restores the safety check and silences the warning, with no formatting change.

## Verification

```
$ black --check --verbose seam/__init__.py
target_version: ['py311']          # no warning

$ black --check .
All done! ✨ 🍰 ✨
110 files would be left unchanged.  # exit 0
```

## Note for reviewers

This value needs bumping alongside any future increase to `requires-python`. The alternative — leaving the warning in place — keeps one less thing to maintain but leaves Black's safety check disabled, so pinning seemed the better trade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5qn7KvBztnwaRTFoL9KNo)_