### PR TITLE
feat: Add SeamHttpInvalidInputError.get_validation_error_messages

### DIFF
--- a/seam/client.py
+++ b/seam/client.py
@@ -146,6 +146,7 @@ class SeamHttpClient(httpx.Client, AbstractSeamHttpClient):
         }
 
         if error_type == "invalid_input":
+            error_details["validation_errors"] = error.get("validation_errors")
             raise SeamHttpInvalidInputError(error_details, status_code, request_id)
 
         raise SeamHttpApiError(error_details, status_code, request_id)

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from .resources import ActionAttempt
 
 
@@ -86,6 +86,19 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
 
         super().__init__(error, status_code, request_id)
         self.code = "invalid_input"
+        self._validation_errors = error.get("validation_errors") or {}
+
+    def get_validation_error_messages(self, param_name: str) -> List[str]:
+        """
+        The validation messages for a request parameter, or an empty list when
+        that parameter has none.
+
+        :param param_name: Name of the request parameter
+        :type param_name: str
+        :rtype: List[str]
+        """
+
+        return self._validation_errors.get(param_name, {}).get("_errors", [])
 
 
 # Action Attempt

--- a/test/http_error_test.py
+++ b/test/http_error_test.py
@@ -45,6 +45,20 @@ def test_seam_http_throws_invalid_input_error(server):
     assert err.status_code == 400
     assert err.code == "invalid_input"
     assert err.request_id.startswith("request")
+    assert err.get_validation_error_messages("device_ids") == [
+        "Expected array, received number"
+    ]
+
+
+def test_seam_http_invalid_input_error_has_no_messages_for_unknown_param(server):
+    endpoint, seed = server
+
+    seam = Seam(api_key=seed["seam_apikey1_token"], endpoint=endpoint)
+
+    with pytest.raises(SeamHttpInvalidInputError) as exc_info:
+        seam.devices.list(device_ids=4242)
+
+    assert exc_info.value.get_validation_error_messages("non_existent_param") == []
 
 
 def test_seam_http_throws_http_error_on_non_standard_response(server):


### PR DESCRIPTION
## Summary
This PR adds the ability to retrieve validation error messages from `SeamHttpInvalidInputError` exceptions, making it easier for users to access detailed validation feedback from the API.

## Key Changes
- Added `List` to type imports in `exceptions.py`
- Added `_validation_errors` attribute to `SeamHttpInvalidInputError` to store validation error details from the API response
- Implemented `get_validation_error_messages(param_name: str)` method to retrieve validation error messages for a specific request parameter
- Updated `client.py` to extract and pass `validation_errors` from the API error response to `SeamHttpInvalidInputError`
- Added test coverage for retrieving validation messages for both existing and non-existent parameters

## Implementation Details
- The `get_validation_error_messages()` method returns a list of error messages for a given parameter name, or an empty list if the parameter has no validation errors
- Validation errors are extracted from the nested structure `validation_errors[param_name]["_errors"]` in the API response
- The implementation gracefully handles missing parameters by returning an empty list rather than raising an exception

https://claude.ai/code/session_012RfnESV5b57QDoxMggXdM9