### PR TITLE
Support Blueprint boolean constraints

### DIFF
--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/codegen/layouts/route.hbs
+++ b/codegen/layouts/route.hbs
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/codegen/lib/layouts/resources.ts
+++ b/codegen/lib/layouts/resources.ts
@@ -107,6 +107,19 @@ const mergeOccurrences = (occurrences: Property[], path: string): Property => {
     )
   }
 
+  if (first.format === 'boolean') {
+    const booleans = occurrences as Array<
+      Extract<Property, { format: 'boolean' }>
+    >
+    const values = booleans.some(({ values }) => values == null)
+      ? undefined
+      : [...new Set(booleans.flatMap(({ values }) => values ?? []))]
+    const merged = { ...first, ...docs }
+    if (values == null) delete merged.values
+    else merged.values = values
+    return merged
+  }
+
   if (first.format === 'object') {
     return {
       ...first,

--- a/codegen/lib/python-type.ts
+++ b/codegen/lib/python-type.ts
@@ -18,6 +18,10 @@ export const mapParameterToPythonType = (parameter: Parameter): string => {
     return parameter.isInt ? 'int' : 'float'
   }
 
+  if (parameter.format === 'boolean') {
+    return mapBooleanToPythonType(parameter.values)
+  }
+
   return mapScalarFormatToPythonType(parameter.format)
 }
 
@@ -51,6 +55,10 @@ export const mapRequiredPropertyToPythonType = (
     return property.isInt ? 'int' : 'float'
   }
 
+  if (property.format === 'boolean') {
+    return mapBooleanToPythonType(property.values)
+  }
+
   // Batch resource properties are lists of the named resource on the wire,
   // though the blueprint types them as records.
   if (property.format === 'record' && 'resourceType' in property) {
@@ -63,6 +71,11 @@ export const mapRequiredPropertyToPythonType = (
 
   return mapScalarFormatToPythonType(property.format)
 }
+
+const mapBooleanToPythonType = (values?: boolean[]): string =>
+  values == null || values.length === 0
+    ? 'bool'
+    : `Literal[${values.map((value) => (value ? 'True' : 'False')).join(', ')}]`
 
 const mapScalarFormatToPythonType = (format: ScalarFormat): string => {
   switch (format) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "@seamapi/python",
       "devDependencies": {
-        "@seamapi/blueprint": "^1.5.1",
+        "@seamapi/blueprint": "^1.6.0",
         "@seamapi/fake-seam-connect": "1.86.0",
         "@seamapi/smith": "^1.1.0",
         "@seamapi/types": "1.1001.0",
@@ -787,9 +787,9 @@
       "license": "MIT"
     },
     "node_modules/@seamapi/blueprint": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.5.1.tgz",
-      "integrity": "sha512-rXHMNDGmaE7OK+tg3e64DnpMHQypN4BuSS+PkVqGUoYc9f+xBMONqPscsHAGi9iU/iyZOJZKEOKOXvMmWaLoLA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-1.6.0.tgz",
+      "integrity": "sha512-+lIriSgog0E0pUjXz/tdRZiVECiSiBcnZ3uU4JRN45RTLs2BQVbR+Ris6/mXwBV1wkpMetdVD3CP1BB1agf6Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@seamapi/blueprint": "^1.5.1",
+    "@seamapi/blueprint": "^1.6.0",
     "@seamapi/fake-seam-connect": "1.86.0",
     "@seamapi/smith": "^1.1.0",
     "@seamapi/types": "1.1001.0",

--- a/seam/resources/access_code.py
+++ b/seam/resources/access_code.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -159,14 +159,14 @@ class AccessCode:
 
         created_at: Optional[str]
         error_code: str
-        is_access_code_error: Optional[bool]
+        is_access_code_error: Optional[Literal[True]]
         message: str
         managed_access_code_id: Optional[str]
         unmanaged_access_code_id: Optional[str]
         change_type: Optional[str]
         modified_fields: Optional[List[ModifiedFields]]
         is_connected_account_error: Optional[bool]
-        is_device_error: Optional[bool]
+        is_device_error: Optional[Literal[False, True]]
         is_bridge_error: Optional[bool]
 
         @classmethod
@@ -345,7 +345,7 @@ class AccessCode:
     is_backup: Optional[bool]
     is_backup_access_code_available: bool
     is_external_modification_allowed: bool
-    is_managed: bool
+    is_managed: Literal[True]
     is_offline_access_code: bool
     is_one_time_use: bool
     is_scheduled_on_device: Optional[bool]

--- a/seam/resources/access_grant.py
+++ b/seam/resources/access_grant.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/access_method.py
+++ b/seam/resources/access_method.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/acs_access_group.py
+++ b/seam/resources/acs_access_group.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -223,7 +223,7 @@ class AcsAccessGroup:
     errors: List[Errors]
     external_type: str
     external_type_display_name: str
-    is_managed: bool
+    is_managed: Literal[True]
     name: str
     pending_mutations: List[PendingMutations]
     warnings: List[Warnings]

--- a/seam/resources/acs_credential.py
+++ b/seam/resources/acs_credential.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -238,7 +238,7 @@ class AcsCredential:
     external_type_display_name: Optional[str]
     is_issued: Optional[bool]
     is_latest_desired_state_synced_with_provider: Optional[bool]
-    is_managed: bool
+    is_managed: Literal[True]
     is_multi_phone_sync_credential: Optional[bool]
     is_one_time_use: Optional[bool]
     issued_at: Optional[str]

--- a/seam/resources/acs_encoder.py
+++ b/seam/resources/acs_encoder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/acs_entrance.py
+++ b/seam/resources/acs_entrance.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/acs_system.py
+++ b/seam/resources/acs_system.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/acs_user.py
+++ b/seam/resources/acs_user.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -304,7 +304,7 @@ class AcsUser:
     external_type_display_name: Optional[str]
     full_name: Optional[str]
     hid_acs_system_id: Optional[str]
-    is_managed: bool
+    is_managed: Literal[True]
     is_suspended: Optional[bool]
     pending_mutations: Optional[List[PendingMutations]]
     phone_number: Optional[str]

--- a/seam/resources/action_attempt.py
+++ b/seam/resources/action_attempt.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -456,7 +456,7 @@ class ActionAttempt:
             external_type_display_name: Optional[str]
             is_issued: Optional[bool]
             is_latest_desired_state_synced_with_provider: Optional[bool]
-            is_managed: bool
+            is_managed: Literal[True, False]
             is_multi_phone_sync_credential: Optional[bool]
             is_one_time_use: Optional[bool]
             issued_at: Optional[str]
@@ -778,7 +778,7 @@ class ActionAttempt:
         external_type_display_name: Optional[str]
         is_issued: Optional[bool]
         is_latest_desired_state_synced_with_provider: Optional[bool]
-        is_managed: Optional[bool]
+        is_managed: Optional[Literal[True, False]]
         is_multi_phone_sync_credential: Optional[bool]
         is_one_time_use: Optional[bool]
         issued_at: Optional[str]

--- a/seam/resources/batch.py
+++ b/seam/resources/batch.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/client_session.py
+++ b/seam/resources/client_session.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/connect_webview.py
+++ b/seam/resources/connect_webview.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/connected_account.py
+++ b/seam/resources/connected_account.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/customer_portal.py
+++ b/seam/resources/customer_portal.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/device.py
+++ b/seam/resources/device.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -153,7 +153,7 @@ class Device:
         created_at: str
         error_code: str
         is_connected_account_error: Optional[bool]
-        is_device_error: Optional[bool]
+        is_device_error: Optional[Literal[False, True]]
         message: str
         is_bridge_error: Optional[bool]
 
@@ -2106,7 +2106,7 @@ class Device:
 
             display_name: str
             end_date_recurrence_rule: Optional[str]
-            matching_start_end_time: Optional[bool]
+            matching_start_end_time: Optional[Literal[True]]
             max_duration: Optional[str]
             min_duration: Optional[str]
             start_date_recurrence_rule: Optional[str]
@@ -2176,7 +2176,7 @@ class Device:
 
             display_name: str
             end_date_recurrence_rule: Optional[str]
-            matching_start_end_time: Optional[bool]
+            matching_start_end_time: Optional[Literal[True]]
             max_duration: Optional[str]
             min_duration: Optional[str]
             start_date_recurrence_rule: Optional[str]
@@ -3282,7 +3282,7 @@ class Device:
     device_type: str
     display_name: str
     errors: List[Errors]
-    is_managed: bool
+    is_managed: Literal[True]
     location: Optional[Location]
     nickname: Optional[str]
     properties: Optional[Properties]

--- a/seam/resources/device_provider.py
+++ b/seam/resources/device_provider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/instant_key.py
+++ b/seam/resources/instant_key.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/noise_threshold.py
+++ b/seam/resources/noise_threshold.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/pagination.py
+++ b/seam/resources/pagination.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/phone.py
+++ b/seam/resources/phone.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/seam_event.py
+++ b/seam/resources/seam_event.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/space.py
+++ b/seam/resources/space.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/thermostat_daily_program.py
+++ b/seam/resources/thermostat_daily_program.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/thermostat_schedule.py
+++ b/seam/resources/thermostat_schedule.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/unmanaged_access_code.py
+++ b/seam/resources/unmanaged_access_code.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -145,14 +145,14 @@ class UnmanagedAccessCode:
 
         created_at: Optional[str]
         error_code: str
-        is_access_code_error: Optional[bool]
+        is_access_code_error: Optional[Literal[True]]
         message: str
         managed_access_code_id: Optional[str]
         unmanaged_access_code_id: Optional[str]
         change_type: Optional[str]
         modified_fields: Optional[List[ModifiedFields]]
         is_connected_account_error: Optional[bool]
-        is_device_error: Optional[bool]
+        is_device_error: Optional[Literal[False, True]]
         is_bridge_error: Optional[bool]
 
         @classmethod
@@ -231,15 +231,15 @@ class UnmanagedAccessCode:
             )
 
     access_code_id: str
-    cannot_be_managed: Optional[bool]
-    cannot_delete_unmanaged_access_code: Optional[bool]
+    cannot_be_managed: Optional[Literal[True]]
+    cannot_delete_unmanaged_access_code: Optional[Literal[True]]
     code: Optional[str]
     created_at: str
     device_id: str
     dormakaba_oracode_metadata: Optional[DormakabaOracodeMetadata]
     ends_at: Optional[str]
     errors: List[Errors]
-    is_managed: bool
+    is_managed: Literal[False]
     name: Optional[str]
     starts_at: Optional[str]
     status: str

--- a/seam/resources/unmanaged_access_grant.py
+++ b/seam/resources/unmanaged_access_grant.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/unmanaged_access_method.py
+++ b/seam/resources/unmanaged_access_method.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/unmanaged_device.py
+++ b/seam/resources/unmanaged_device.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping
@@ -93,7 +93,7 @@ class UnmanagedDevice:
         created_at: str
         error_code: str
         is_connected_account_error: Optional[bool]
-        is_device_error: Optional[bool]
+        is_device_error: Optional[Literal[False, True]]
         message: str
         is_bridge_error: Optional[bool]
 
@@ -367,7 +367,7 @@ class UnmanagedDevice:
     device_id: str
     device_type: str
     errors: List[Errors]
-    is_managed: bool
+    is_managed: Literal[False]
     location: Optional[Location]
     properties: Optional[Properties]
     warnings: List[Warnings]

--- a/seam/resources/unmanaged_user_identity.py
+++ b/seam/resources/unmanaged_user_identity.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/user_identity.py
+++ b/seam/resources/user_identity.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/webhook.py
+++ b/seam/resources/webhook.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/resources/workspace.py
+++ b/seam/resources/workspace.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
 from ..resource_mapping import ResourceMapping

--- a/seam/routes/access_codes.py
+++ b/seam/routes/access_codes.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/access_codes_simulate.py
+++ b/seam/routes/access_codes_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/access_codes_unmanaged.py
+++ b/seam/routes/access_codes_unmanaged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/access_grants.py
+++ b/seam/routes/access_grants.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/access_grants_unmanaged.py
+++ b/seam/routes/access_grants_unmanaged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata
@@ -52,7 +52,7 @@ class AbstractAccessGrantsUnmanaged(abc.ABC):
         self,
         *,
         access_grant_id: str,
-        is_managed: bool,
+        is_managed: Literal[True],
         access_grant_key: Optional[str] = None,
     ) -> None:
         """Updates an unmanaged Access Grant to make it managed.
@@ -161,7 +161,7 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
         self,
         *,
         access_grant_id: str,
-        is_managed: bool,
+        is_managed: Literal[True],
         access_grant_key: Optional[str] = None,
     ) -> None:
         """Updates an unmanaged Access Grant to make it managed.

--- a/seam/routes/access_methods.py
+++ b/seam/routes/access_methods.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/access_methods_unmanaged.py
+++ b/seam/routes/access_methods_unmanaged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs.py
+++ b/seam/routes/acs.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_access_groups.py
+++ b/seam/routes/acs_access_groups.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_credentials.py
+++ b/seam/routes/acs_credentials.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_encoders.py
+++ b/seam/routes/acs_encoders.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_encoders_simulate.py
+++ b/seam/routes/acs_encoders_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_entrances.py
+++ b/seam/routes/acs_entrances.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_systems.py
+++ b/seam/routes/acs_systems.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/acs_users.py
+++ b/seam/routes/acs_users.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/action_attempts.py
+++ b/seam/routes/action_attempts.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/client_sessions.py
+++ b/seam/routes/client_sessions.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/connect_webviews.py
+++ b/seam/routes/connect_webviews.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/connected_accounts.py
+++ b/seam/routes/connected_accounts.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/connected_accounts_simulate.py
+++ b/seam/routes/connected_accounts_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/customers.py
+++ b/seam/routes/customers.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/devices.py
+++ b/seam/routes/devices.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/devices_simulate.py
+++ b/seam/routes/devices_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/devices_unmanaged.py
+++ b/seam/routes/devices_unmanaged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata
@@ -81,7 +81,7 @@ class AbstractDevicesUnmanaged(abc.ABC):
         *,
         device_id: str,
         custom_metadata: Optional[Dict[str, Any]] = None,
-        is_managed: Optional[bool] = None,
+        is_managed: Optional[Literal[True]] = None,
     ) -> None:
         """Updates a specified `unmanaged device <https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices>`_. To convert an unmanaged device to managed, set ``is_managed`` to ``true``.
 
@@ -230,7 +230,7 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
         *,
         device_id: str,
         custom_metadata: Optional[Dict[str, Any]] = None,
-        is_managed: Optional[bool] = None,
+        is_managed: Optional[Literal[True]] = None,
     ) -> None:
         """Updates a specified `unmanaged device <https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices>`_. To convert an unmanaged device to managed, set ``is_managed`` to ``true``.
 

--- a/seam/routes/events.py
+++ b/seam/routes/events.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/instant_keys.py
+++ b/seam/routes/instant_keys.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/locks.py
+++ b/seam/routes/locks.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/locks_simulate.py
+++ b/seam/routes/locks_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/noise_sensors.py
+++ b/seam/routes/noise_sensors.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/noise_sensors_noise_thresholds.py
+++ b/seam/routes/noise_sensors_noise_thresholds.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/noise_sensors_simulate.py
+++ b/seam/routes/noise_sensors_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/phones.py
+++ b/seam/routes/phones.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/phones_simulate.py
+++ b/seam/routes/phones_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/spaces.py
+++ b/seam/routes/spaces.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/thermostats.py
+++ b/seam/routes/thermostats.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/thermostats_daily_programs.py
+++ b/seam/routes/thermostats_daily_programs.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/thermostats_schedules.py
+++ b/seam/routes/thermostats_schedules.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/thermostats_simulate.py
+++ b/seam/routes/thermostats_simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/user_identities.py
+++ b/seam/routes/user_identities.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/user_identities_unmanaged.py
+++ b/seam/routes/user_identities_unmanaged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata
@@ -45,7 +45,7 @@ class AbstractUserIdentitiesUnmanaged(abc.ABC):
     def update(
         self,
         *,
-        is_managed: bool,
+        is_managed: Literal[True],
         user_identity_id: str,
         user_identity_key: Optional[str] = None,
     ) -> None:
@@ -144,7 +144,7 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
     def update(
         self,
         *,
-        is_managed: bool,
+        is_managed: Literal[True],
         user_identity_id: str,
         user_identity_key: Optional[str] = None,
     ) -> None:

--- a/seam/routes/webhooks.py
+++ b/seam/routes/webhooks.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/seam/routes/workspaces.py
+++ b/seam/routes/workspaces.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, List, Dict, Union
+from typing import Optional, Any, List, Dict, Literal, Union
 import abc
 from ..client import SeamHttpClient
 from ..route import route_metadata

--- a/test/resource_types_test.py
+++ b/test/resource_types_test.py
@@ -1,0 +1,35 @@
+# mypy: warn_unused_ignores=True
+
+from typing import Literal, assert_type
+
+from seam.resources import AccessCode, ActionAttempt, UnmanagedAccessCode
+
+
+def _assert_access_code_narrowing(
+    code: AccessCode | UnmanagedAccessCode,
+) -> None:
+    if code.is_managed:
+        assert_type(code, AccessCode)
+    else:
+        assert_type(code, UnmanagedAccessCode)
+
+
+def _assert_boolean_shapes(
+    code: AccessCode,
+    unmanaged_code: UnmanagedAccessCode,
+    credential: ActionAttempt.Result.AcsCredentialOnSeam,
+) -> None:
+    assert_type(code.is_backup_access_code_available, bool)
+    assert_type(code.errors[0].is_access_code_error, Literal[True] | None)
+    assert_type(unmanaged_code.errors[0].is_connected_account_error, bool | None)
+    assert_type(credential.is_managed, Literal[True, False])
+
+
+def _assert_opposite_literal_is_rejected(code: UnmanagedAccessCode) -> None:
+    code.is_managed = True  # type: ignore[assignment]
+
+
+def test_access_code_resources_narrow_on_is_managed():
+    assert callable(_assert_access_code_narrowing)
+    assert callable(_assert_boolean_shapes)
+    assert callable(_assert_opposite_literal_is_rejected)


### PR DESCRIPTION
## Summary
- update `@seamapi/blueprint` to 1.6.0
- generate `Literal[True]` and `Literal[False]` for constrained booleans
- preserve unconstrained booleans as `bool` and multiple values as `Literal[...]`
- merge boolean constraints across flattened variants and regenerate the SDK
- add regression coverage for access-code union narrowing and opposite-literal rejection

## Verification
- `npm run typecheck`
- `npm run lint`
- `just lint`
- `just test` (162 passed)