### PR TITLE
feat: expose structured validation errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,10 @@ Contents
 
   * `Asynchronous Usage`_
 
+  * `Error Handling`_
+
+    * `Validation errors`_
+
   * `Requests without a Workspace in Scope`_
 
     * `Personal Access Token without a Workspace`_
@@ -485,6 +489,38 @@ and ``flatten`` returns an async generator.
 
 The ``AsyncSeamWithoutWorkspace`` client is the equivalent async variant of
 ``SeamWithoutWorkspace``.
+
+Error Handling
+~~~~~~~~~~~~~~
+
+Requests rejected by the Seam API raise a ``SeamHttpApiError`` subclass
+carrying the HTTP ``status_code``, API error ``code``, and ``request_id``.
+
+Validation errors
+^^^^^^^^^^^^^^^^^
+
+When the API rejects a request because a parameter is invalid, it raises a
+``SeamHttpInvalidInputError``. Look up messages for a parameter you are already
+rendering, for example a field in a form:
+
+.. code-block:: python
+
+  from seam import SeamHttpInvalidInputError
+
+  try:
+      seam.devices.list(device_ids=["not-a-uuid"])
+  except SeamHttpInvalidInputError as error:
+      print(error.get_validation_error_messages("device_ids"))
+
+Or read every parameter that failed validation to summarize the request:
+
+.. code-block:: python
+
+  for validation_error in error.validation_errors:
+      print(
+          f"{validation_error.parameter_name}: "
+          f"{', '.join(validation_error.error_messages)}"
+      )
 
 Requests without a Workspace in Scope
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/seam/__init__.py
+++ b/seam/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
     SeamHttpApiError,
     SeamHttpUnauthorizedError,
     SeamHttpInvalidInputError,
+    SeamValidationError,
     SeamActionAttemptError,
     SeamActionAttemptFailedError,
     SeamActionAttemptTimeoutError,

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -1,5 +1,14 @@
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from .resources import ActionAttempt
+
+
+@dataclass(frozen=True)
+class SeamValidationError:
+    """A request parameter that failed validation and its error messages."""
+
+    parameter_name: str
+    error_messages: List[str]
 
 
 # HTTP
@@ -87,6 +96,18 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
         super().__init__(error, status_code, request_id)
         self.code = "invalid_input"
         self._validation_errors = error.get("validation_errors") or {}
+
+    @property
+    def validation_errors(self) -> List[SeamValidationError]:
+        """Validation errors, one entry per failed request parameter."""
+
+        return [
+            SeamValidationError(
+                param_name, self.get_validation_error_messages(param_name)
+            )
+            for param_name in self._validation_errors
+            if param_name != "_errors"
+        ]
 
     def get_validation_error_messages(self, param_name: str) -> List[str]:
         """

--- a/test/http_error_test.py
+++ b/test/http_error_test.py
@@ -5,6 +5,7 @@ from seam.exceptions import (
     SeamHttpApiError,
     SeamHttpInvalidInputError,
     SeamHttpUnauthorizedError,
+    SeamValidationError,
 )
 
 
@@ -47,6 +48,29 @@ def test_seam_http_throws_invalid_input_error(server):
     assert err.request_id.startswith("request")
     assert err.get_validation_error_messages("device_ids") == [
         "Expected array, received number"
+    ]
+    assert err.validation_errors == [
+        SeamValidationError(
+            parameter_name="device_ids",
+            error_messages=["Expected array, received number"],
+        )
+    ]
+
+
+def test_validation_errors_exclude_request_wide_errors():
+    err = SeamHttpInvalidInputError(
+        {
+            "validation_errors": {
+                "_errors": ["Request is invalid"],
+                "device_ids": {"_errors": ["Invalid device IDs"]},
+            }
+        },
+        400,
+        None,
+    )
+
+    assert err.validation_errors == [
+        SeamValidationError("device_ids", ["Invalid device IDs"])
     ]
 
 


### PR DESCRIPTION
## Summary

- expose all invalid parameters as typed `SeamValidationError` objects
- preserve per-parameter message lookup and omit request-wide `_errors`
- document both validation error access patterns

## Tests

- `just lint`
- `just test`
- `npm run lint`

Part of [ENG-2962](https://linear.app/seam/issue/ENG-2962/port-structured-validation-errors-to-all-sdks).
