### PR TITLE
docs: document status-dependent action attempt values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,28 @@ When the ``wait_for_action_attempt`` option is enabled, the SDK:
 - Raises a ``SeamActionAttemptTimeoutError`` if the action attempt is still pending when the ``timeout`` is reached.
 - Both errors expose an ``action_attempt`` property.
 
+Each action attempt parses to a class for its ``action_type`` and ``status`` pair,
+e.g., ``LockDoorSuccessActionAttempt``.
+The ``error`` and ``result`` attributes are ``None``
+except for the status that populates them,
+so narrow on the ``status`` before reading them:
+
+.. code-block:: python
+
+  action_attempt = seam.locks.unlock_door(
+      device_id=device_id,
+      wait_for_action_attempt=False,
+  )
+
+  if action_attempt.status == "success":
+      print(action_attempt.result)  # The result is not None here.
+
+  if action_attempt.status == "error":
+      print(action_attempt.error.message)  # The error is not None here.
+
+Waiting for an action attempt returns a ``SuccessActionAttempt``,
+so the ``result`` is immediately usable.
+
 If you already have an action attempt ID
 and want to wait for it to resolve, simply use
 


### PR DESCRIPTION
Follow-up to #632: documents the `(action_type, status)` action attempt classes in the README's Action Attempts section — how `error` and `result` are `None` outside their status, with a narrow-on-`status` example:

```python
if action_attempt.status == "success":
    print(action_attempt.result)  # The result is not None here.

if action_attempt.status == "error":
    print(action_attempt.error.message)  # The error is not None here.
```

Also notes that waiting returns a `SuccessActionAttempt`. README-only change; rstcheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdWS7o3htQ9cNxhCWL5Frp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdWS7o3htQ9cNxhCWL5Frp)_