### PR TITLE
feat: Add a common SeamError base for SDK errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -515,6 +515,18 @@ The ``AsyncSeamWithoutWorkspace`` client is the equivalent async variant of
 Error Handling
 ~~~~~~~~~~~~~~
 
+Errors raised by the SDK subclass ``SeamError``, so one except block
+covers everything the SDK raises:
+
+.. code-block:: python
+
+  from seam import SeamError
+
+  try:
+      seam.locks.unlock_door(device_id=device_id)
+  except SeamError as error:
+      print(error)
+
 Requests rejected by the Seam API raise a ``SeamHttpApiError`` subclass
 carrying the HTTP ``status_code``, API error ``code``, and ``request_id``.
 

--- a/seam/__init__.py
+++ b/seam/__init__.py
@@ -6,6 +6,7 @@ from httpx_retries import Retry
 from .options import SeamInvalidOptionsError
 from .auth import SeamInvalidTokenError
 from .exceptions import (
+    SeamError,
     SeamHttpApiError,
     SeamHttpUnauthorizedError,
     SeamHttpInvalidInputError,

--- a/seam/auth.py
+++ b/seam/auth.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from .exceptions import SeamError
 from .options import (
     SeamInvalidOptionsError,
     is_seam_options_with_api_key,
@@ -15,7 +16,7 @@ from .token import (
 )
 
 
-class SeamInvalidTokenError(Exception):
+class SeamInvalidTokenError(SeamError):
     """
     Exception raised when an invalid token is provided to the Seam client.
 

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -11,8 +11,12 @@ class SeamValidationError:
     error_messages: List[str]
 
 
+class SeamError(Exception):
+    """Base exception for all errors raised by the Seam SDK."""
+
+
 # HTTP
-class SeamHttpApiError(Exception):
+class SeamHttpApiError(SeamError):
     """
     Base exception for Seam HTTP API errors.
 
@@ -123,7 +127,7 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
 
 
 # Action Attempt
-class SeamActionAttemptError(Exception):
+class SeamActionAttemptError(SeamError):
     """
     Base exception for Seam Action Attempt errors.
 

--- a/seam/options.py
+++ b/seam/options.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional
 
 from .constants import DEFAULT_ENDPOINT
+from .exceptions import SeamError
 
 
 def get_endpoint(endpoint: Optional[str] = None):
@@ -31,7 +32,7 @@ def get_endpoint_from_env():
     return seam_endpoint or seam_api_url
 
 
-class SeamInvalidOptionsError(Exception):
+class SeamInvalidOptionsError(SeamError):
     """
     Exception raised when invalid options are provided to Seam client.
 

--- a/seam/url_search_params_serializer.py
+++ b/seam/url_search_params_serializer.py
@@ -40,12 +40,13 @@ from decimal import Decimal
 from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
 from urllib.parse import parse_qsl
 
+from .exceptions import SeamError
 from .null import is_null
 
 Params = Mapping[str, Any]
 
 
-class UnserializableParamError(Exception):
+class UnserializableParamError(SeamError):
     """Exception raised when a param could not be serialized.
 
     :ivar name: Name of the param that could not be serialized

--- a/test/seam_error_test.py
+++ b/test/seam_error_test.py
@@ -1,0 +1,37 @@
+from seam import (
+    SeamActionAttemptError,
+    SeamActionAttemptFailedError,
+    SeamActionAttemptTimeoutError,
+    SeamError,
+    SeamHttpApiError,
+    SeamHttpInvalidInputError,
+    SeamHttpUnauthorizedError,
+    SeamInvalidOptionsError,
+    SeamInvalidTokenError,
+    UnserializableParamError,
+)
+
+
+def test_seam_error_is_the_base_of_every_sdk_error():
+    for error_class in [
+        SeamHttpApiError,
+        SeamHttpUnauthorizedError,
+        SeamHttpInvalidInputError,
+        SeamActionAttemptError,
+        SeamActionAttemptFailedError,
+        SeamActionAttemptTimeoutError,
+        SeamInvalidOptionsError,
+        SeamInvalidTokenError,
+        UnserializableParamError,
+    ]:
+        assert issubclass(error_class, SeamError)
+
+
+def test_seam_error_catches_an_api_error():
+    error = SeamHttpApiError(
+        {"type": "device_not_found", "message": "Device not found"},
+        404,
+        "request-id",
+    )
+
+    assert isinstance(error, SeamError)


### PR DESCRIPTION
## What

Adds `SeamError` as a common base exception and rebases every SDK-raised error onto it:

- `SeamHttpApiError` (and thus `SeamHttpUnauthorizedError`, `SeamHttpInvalidInputError`)
- `SeamActionAttemptError` (and thus `SeamActionAttemptFailedError`, `SeamActionAttemptTimeoutError`)
- `SeamInvalidOptionsError`
- `SeamInvalidTokenError`
- `UnserializableParamError`

`SeamError` is exported from the package root and documented in the README's Error Handling section.

## Why

The SDK audit fix wave (see the PHP and JS SDKs) is adding new error classes here next (invalid response, invalid webhook payload). Python currently has no common exception root — every SDK error subclasses `Exception` directly, so `except SeamError:` was not expressible and the README's own webhook example had to resort to `except Exception:`. The PHP SDK made "one catch block covers everything from the SDK" an explicit goal via its `SeamException` interface; this is the Python equivalent.

Non-breaking: all existing classes keep their current bases and behavior; they only gain the new root. (The webhook verification error is a re-exported svix type today; it joins the hierarchy in a follow-up PR that reworks webhook error handling.)

## Testing

- New `test/seam_error_test.py` asserts every public SDK error subclasses `SeamError`.
- Full suite: 187 passed. `black --check`, `pylint` (10.00), `mypy`, `rstcheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_