### PR TITLE
fix: Raise a Seam error for a success response that is malformed

### DIFF
--- a/codegen/layouts/partials/route-method.hbs
+++ b/codegen/layouts/partials/route-method.hbs
@@ -24,7 +24,7 @@
 
         return {{#if isAsync}}await resolve_action_attempt_async{{else}}resolve_action_attempt{{/if}}(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(unwrap(res, "action_attempt", "{{path}}")),
             wait_for_action_attempt=wait_for_action_attempt
         )
 {{else if (eq returnType "None")}}
@@ -32,8 +32,8 @@
         return None
 {{else if (isListType returnType)}}
 
-        return [{{fromDict (listItemType returnType)}}(item) for item in res{{#each returnPath}}["{{this}}"]{{/each}}]
+        return [{{fromDict (listItemType returnType)}}(item) for item in unwrap_list(res, "{{returnPath.[0]}}", "{{path}}")]
 {{else}}
 
-        return {{fromDict returnType}}(res{{#each returnPath}}["{{this}}"]{{/each}})
+        return {{fromDict returnType}}(unwrap(res, "{{returnPath.[0]}}", "{{path}}"))
 {{/if}}

--- a/codegen/layouts/route.hbs
+++ b/codegen/layouts/route.hbs
@@ -14,6 +14,12 @@ from .{{module}} import {{abstractClassName}}, {{className}}, {{asyncAbstractCla
 {{#if importResolveActionAttempt}}
 from ..modules.action_attempts import resolve_action_attempt, resolve_action_attempt_async
 {{/if}}
+{{#if importUnwrap}}
+from ..response import unwrap
+{{/if}}
+{{#if importUnwrapList}}
+from ..response import unwrap_list
+{{/if}}
 
 
 {{> abstract-route-class abstractClass}}

--- a/codegen/lib/layouts/route.ts
+++ b/codegen/lib/layouts/route.ts
@@ -61,6 +61,8 @@ export interface RouteLayoutContext {
   }>
   importResolveActionAttempt: boolean
   importNull: boolean
+  importUnwrap: boolean
+  importUnwrapList: boolean
   methods: MethodLayoutContext[]
 }
 
@@ -130,6 +132,16 @@ export const setRouteLayoutContext = (cls: ClassModel): RouteLayoutContext => {
     params.some(({ isNullable }) => isNullable),
   )
 
+  const importUnwrap = methods.some(
+    ({ returnPath, returnType }) =>
+      returnPath.length > 0 && !returnType.startsWith('List['),
+  )
+
+  const importUnwrapList = methods.some(
+    ({ returnPath, returnType }) =>
+      returnPath.length > 0 && returnType.startsWith('List['),
+  )
+
   const showPass =
     cls.methods.length === 0 && cls.childClassIdentifiers.length === 0
 
@@ -172,6 +184,8 @@ export const setRouteLayoutContext = (cls: ClassModel): RouteLayoutContext => {
     })),
     importResolveActionAttempt,
     importNull,
+    importUnwrap,
+    importUnwrapList,
     methods,
   }
 }

--- a/seam/__init__.py
+++ b/seam/__init__.py
@@ -8,6 +8,7 @@ from .auth import SeamInvalidTokenError
 from .exceptions import (
     SeamError,
     SeamHttpApiError,
+    SeamHttpInvalidResponseError,
     SeamHttpUnauthorizedError,
     SeamHttpInvalidInputError,
     SeamValidationError,

--- a/seam/client.py
+++ b/seam/client.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from json import JSONDecodeError
 from typing import Any, Dict, Optional
 from importlib.metadata import version
 import abc
@@ -68,7 +69,13 @@ class SeamHttpResponseHandler:
             self._handle_error_response(response)
 
         if "application/json" in response.headers.get("content-type", ""):
-            return response.json()
+            try:
+                return response.json()
+            except JSONDecodeError:
+                # A body that lies about its content type is handed on as
+                # text, so readers report an invalid response instead of
+                # leaking a decode error.
+                return response.text
 
         return response.text
 

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -16,6 +16,36 @@ class SeamError(Exception):
 
 
 # HTTP
+class SeamHttpInvalidResponseError(SeamError):
+    """
+    Exception raised when a success response from the Seam API has an
+    unexpected shape, e.g., a proxy rewrote the body or the expected
+    response key is missing.
+
+    :ivar path: The request path that produced the response
+    :vartype path: str
+    :ivar response_key: The response key the SDK expected to read
+    :vartype response_key: str
+    """
+
+    def __init__(self, path: str, response_key: str, reason: str):
+        """
+        :param path: The request path that produced the response
+        :type path: str
+        :param response_key: The response key the SDK expected to read
+        :type response_key: str
+        :param reason: Description of how the response diverged
+        :type reason: str
+        """
+
+        super().__init__(
+            f"Seam returned an invalid response for {path}: "
+            f'expected "{response_key}", {reason}'
+        )
+        self.path = path
+        self.response_key = response_key
+
+
 class SeamHttpApiError(SeamError):
     """
     Base exception for Seam HTTP API errors.

--- a/seam/modules/action_attempts.py
+++ b/seam/modules/action_attempts.py
@@ -6,6 +6,7 @@ from ..client import AsyncSeamHttpClient, SeamHttpClient
 from ..exceptions import SeamActionAttemptFailedError, SeamActionAttemptTimeoutError
 from ..options import SeamInvalidOptionsError
 from ..resources import ActionAttempt, SuccessActionAttempt, action_attempt_from_dict
+from ..response import unwrap
 
 TIMEOUT = 5.0
 POLLING_INTERVAL = 0.5
@@ -72,7 +73,9 @@ def get_action_attempt(client: SeamHttpClient, action_attempt_id: str) -> Action
         "/action_attempts/get", params={"action_attempt_id": action_attempt_id}
     )
 
-    return action_attempt_from_dict(res["action_attempt"])
+    return action_attempt_from_dict(
+        unwrap(res, "action_attempt", "/action_attempts/get")
+    )
 
 
 def poll_until_ready(
@@ -142,7 +145,9 @@ async def get_action_attempt_async(
         "/action_attempts/get", params={"action_attempt_id": action_attempt_id}
     )
 
-    return action_attempt_from_dict(res["action_attempt"])
+    return action_attempt_from_dict(
+        unwrap(res, "action_attempt", "/action_attempts/get")
+    )
 
 
 async def poll_until_ready_async(

--- a/seam/response.py
+++ b/seam/response.py
@@ -1,0 +1,52 @@
+"""Read success response payloads defensively.
+
+A 2xx response with an unexpected shape, e.g., a proxy rewrote the body or
+the response key was renamed, raises the SDK's own error instead of leaking
+a bare KeyError or TypeError from inside a generated route method.
+"""
+
+from typing import Any, Dict, List
+
+from .exceptions import SeamHttpInvalidResponseError
+
+
+def _read_response_key(res: Any, response_key: str, path: str) -> Any:
+    if not isinstance(res, dict):
+        raise SeamHttpInvalidResponseError(
+            path,
+            response_key,
+            f"got {type(res).__name__} instead of a response object",
+        )
+
+    if response_key not in res:
+        raise SeamHttpInvalidResponseError(
+            path, response_key, "which the response does not contain"
+        )
+
+    return res[response_key]
+
+
+def unwrap(res: Any, response_key: str, path: str) -> Dict[str, Any]:
+    """Read an object under the response key, or raise for a malformed response."""
+
+    value = _read_response_key(res, response_key, path)
+
+    if not isinstance(value, dict):
+        raise SeamHttpInvalidResponseError(
+            path, response_key, f"got {type(value).__name__} instead of an object"
+        )
+
+    return value
+
+
+def unwrap_list(res: Any, response_key: str, path: str) -> List[Any]:
+    """Read a list under the response key, or raise for a malformed response."""
+
+    value = _read_response_key(res, response_key, path)
+
+    if not isinstance(value, list):
+        raise SeamHttpInvalidResponseError(
+            path, response_key, f"got {type(value).__name__} instead of a list"
+        )
+
+    return value

--- a/seam/routes/access_codes.py
+++ b/seam/routes/access_codes.py
@@ -16,6 +16,8 @@ from .access_codes_unmanaged import (
     AbstractAsyncAccessCodesUnmanaged,
     AsyncAccessCodesUnmanaged,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessCodes(abc.ABC):
@@ -865,7 +867,7 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.post("/access_codes/create", json=json_payload)
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/create"))
 
     @route_metadata(
         path="/access_codes/create_multiple",
@@ -973,7 +975,12 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.put("/access_codes/create_multiple", json=json_payload)
 
-        return [AccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            AccessCode.from_dict(item)
+            for item in unwrap_list(
+                res, "access_codes", "/access_codes/create_multiple"
+            )
+        ]
 
     @route_metadata(
         path="/access_codes/delete", has_required_parameters=True, has_pagination=False
@@ -1027,7 +1034,9 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.get("/access_codes/generate_code", params=params)
 
-        return AccessCode.from_dict(res["generated_code"])
+        return AccessCode.from_dict(
+            unwrap(res, "generated_code", "/access_codes/generate_code")
+        )
 
     @route_metadata(
         path="/access_codes/get", has_required_parameters=True, has_pagination=False
@@ -1066,7 +1075,7 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.get("/access_codes/get", params=params)
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/get"))
 
     @route_metadata(
         path="/access_codes/list", has_required_parameters=True, has_pagination=True
@@ -1142,7 +1151,10 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.get("/access_codes/list", params=params)
 
-        return [AccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            AccessCode.from_dict(item)
+            for item in unwrap_list(res, "access_codes", "/access_codes/list")
+        ]
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",
@@ -1179,7 +1191,9 @@ class AccessCodes(AbstractAccessCodes):
             "/access_codes/pull_backup_access_code", json=json_payload
         )
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(
+            unwrap(res, "access_code", "/access_codes/pull_backup_access_code")
+        )
 
     @route_metadata(
         path="/access_codes/report_device_constraints",
@@ -1494,7 +1508,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.post("/access_codes/create", json=json_payload)
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/create"))
 
     @route_metadata(
         path="/access_codes/create_multiple",
@@ -1602,7 +1616,12 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.put("/access_codes/create_multiple", json=json_payload)
 
-        return [AccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            AccessCode.from_dict(item)
+            for item in unwrap_list(
+                res, "access_codes", "/access_codes/create_multiple"
+            )
+        ]
 
     @route_metadata(
         path="/access_codes/delete", has_required_parameters=True, has_pagination=False
@@ -1658,7 +1677,9 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.get("/access_codes/generate_code", params=params)
 
-        return AccessCode.from_dict(res["generated_code"])
+        return AccessCode.from_dict(
+            unwrap(res, "generated_code", "/access_codes/generate_code")
+        )
 
     @route_metadata(
         path="/access_codes/get", has_required_parameters=True, has_pagination=False
@@ -1697,7 +1718,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.get("/access_codes/get", params=params)
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/get"))
 
     @route_metadata(
         path="/access_codes/list", has_required_parameters=True, has_pagination=True
@@ -1773,7 +1794,10 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.get("/access_codes/list", params=params)
 
-        return [AccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            AccessCode.from_dict(item)
+            for item in unwrap_list(res, "access_codes", "/access_codes/list")
+        ]
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",
@@ -1810,7 +1834,9 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
             "/access_codes/pull_backup_access_code", json=json_payload
         )
 
-        return AccessCode.from_dict(res["access_code"])
+        return AccessCode.from_dict(
+            unwrap(res, "access_code", "/access_codes/pull_backup_access_code")
+        )
 
     @route_metadata(
         path="/access_codes/report_device_constraints",

--- a/seam/routes/access_codes_simulate.py
+++ b/seam/routes/access_codes_simulate.py
@@ -3,6 +3,7 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import UnmanagedAccessCode
+from ..response import unwrap
 
 
 class AbstractAccessCodesSimulate(abc.ABC):
@@ -87,7 +88,13 @@ class AccessCodesSimulate(AbstractAccessCodesSimulate):
             "/access_codes/simulate/create_unmanaged_access_code", json=json_payload
         )
 
-        return UnmanagedAccessCode.from_dict(res["access_code"])
+        return UnmanagedAccessCode.from_dict(
+            unwrap(
+                res,
+                "access_code",
+                "/access_codes/simulate/create_unmanaged_access_code",
+            )
+        )
 
 
 class AsyncAccessCodesSimulate(AbstractAsyncAccessCodesSimulate):
@@ -132,4 +139,10 @@ class AsyncAccessCodesSimulate(AbstractAsyncAccessCodesSimulate):
             "/access_codes/simulate/create_unmanaged_access_code", json=json_payload
         )
 
-        return UnmanagedAccessCode.from_dict(res["access_code"])
+        return UnmanagedAccessCode.from_dict(
+            unwrap(
+                res,
+                "access_code",
+                "/access_codes/simulate/create_unmanaged_access_code",
+            )
+        )

--- a/seam/routes/access_codes_unmanaged.py
+++ b/seam/routes/access_codes_unmanaged.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import UnmanagedAccessCode
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessCodesUnmanaged(abc.ABC):
@@ -355,7 +357,9 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
         res = self.client.get("/access_codes/unmanaged/get", params=params)
 
-        return UnmanagedAccessCode.from_dict(res["access_code"])
+        return UnmanagedAccessCode.from_dict(
+            unwrap(res, "access_code", "/access_codes/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_codes/unmanaged/list",
@@ -406,7 +410,10 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
         res = self.client.get("/access_codes/unmanaged/list", params=params)
 
-        return [UnmanagedAccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            UnmanagedAccessCode.from_dict(item)
+            for item in unwrap_list(res, "access_codes", "/access_codes/unmanaged/list")
+        ]
 
     @route_metadata(
         path="/access_codes/unmanaged/update",
@@ -583,7 +590,9 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
         res = await self.client.get("/access_codes/unmanaged/get", params=params)
 
-        return UnmanagedAccessCode.from_dict(res["access_code"])
+        return UnmanagedAccessCode.from_dict(
+            unwrap(res, "access_code", "/access_codes/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_codes/unmanaged/list",
@@ -634,7 +643,10 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
         res = await self.client.get("/access_codes/unmanaged/list", params=params)
 
-        return [UnmanagedAccessCode.from_dict(item) for item in res["access_codes"]]
+        return [
+            UnmanagedAccessCode.from_dict(item)
+            for item in unwrap_list(res, "access_codes", "/access_codes/unmanaged/list")
+        ]
 
     @route_metadata(
         path="/access_codes/unmanaged/update",

--- a/seam/routes/access_grants.py
+++ b/seam/routes/access_grants.py
@@ -10,6 +10,8 @@ from .access_grants_unmanaged import (
     AbstractAsyncAccessGrantsUnmanaged,
     AsyncAccessGrantsUnmanaged,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessGrants(abc.ABC):
@@ -581,7 +583,9 @@ class AccessGrants(AbstractAccessGrants):
 
         res = self.client.post("/access_grants/create", json=json_payload)
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/create")
+        )
 
     @route_metadata(
         path="/access_grants/delete", has_required_parameters=True, has_pagination=False
@@ -638,7 +642,7 @@ class AccessGrants(AbstractAccessGrants):
 
         res = self.client.get("/access_grants/get", params=params)
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(unwrap(res, "access_grant", "/access_grants/get"))
 
     @route_metadata(
         path="/access_grants/get_related",
@@ -710,7 +714,7 @@ class AccessGrants(AbstractAccessGrants):
 
         res = self.client.get("/access_grants/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/access_grants/get_related"))
 
     @route_metadata(
         path="/access_grants/list", has_required_parameters=False, has_pagination=True
@@ -792,7 +796,10 @@ class AccessGrants(AbstractAccessGrants):
 
         res = self.client.get("/access_grants/list", params=params)
 
-        return [AccessGrant.from_dict(item) for item in res["access_grants"]]
+        return [
+            AccessGrant.from_dict(item)
+            for item in unwrap_list(res, "access_grants", "/access_grants/list")
+        ]
 
     @route_metadata(
         path="/access_grants/request_access_methods",
@@ -827,7 +834,9 @@ class AccessGrants(AbstractAccessGrants):
             "/access_grants/request_access_methods", json=json_payload
         )
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/request_access_methods")
+        )
 
     @route_metadata(
         path="/access_grants/update", has_required_parameters=True, has_pagination=False
@@ -984,7 +993,9 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         res = await self.client.post("/access_grants/create", json=json_payload)
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/create")
+        )
 
     @route_metadata(
         path="/access_grants/delete", has_required_parameters=True, has_pagination=False
@@ -1041,7 +1052,7 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         res = await self.client.get("/access_grants/get", params=params)
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(unwrap(res, "access_grant", "/access_grants/get"))
 
     @route_metadata(
         path="/access_grants/get_related",
@@ -1113,7 +1124,7 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         res = await self.client.get("/access_grants/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/access_grants/get_related"))
 
     @route_metadata(
         path="/access_grants/list", has_required_parameters=False, has_pagination=True
@@ -1195,7 +1206,10 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         res = await self.client.get("/access_grants/list", params=params)
 
-        return [AccessGrant.from_dict(item) for item in res["access_grants"]]
+        return [
+            AccessGrant.from_dict(item)
+            for item in unwrap_list(res, "access_grants", "/access_grants/list")
+        ]
 
     @route_metadata(
         path="/access_grants/request_access_methods",
@@ -1230,7 +1244,9 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
             "/access_grants/request_access_methods", json=json_payload
         )
 
-        return AccessGrant.from_dict(res["access_grant"])
+        return AccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/request_access_methods")
+        )
 
     @route_metadata(
         path="/access_grants/update", has_required_parameters=True, has_pagination=False

--- a/seam/routes/access_grants_unmanaged.py
+++ b/seam/routes/access_grants_unmanaged.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import UnmanagedAccessGrant
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessGrantsUnmanaged(abc.ABC):
@@ -166,7 +168,9 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
         res = self.client.get("/access_grants/unmanaged/get", params=params)
 
-        return UnmanagedAccessGrant.from_dict(res["access_grant"])
+        return UnmanagedAccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_grants/unmanaged/list",
@@ -215,7 +219,12 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
         res = self.client.get("/access_grants/unmanaged/list", params=params)
 
-        return [UnmanagedAccessGrant.from_dict(item) for item in res["access_grants"]]
+        return [
+            UnmanagedAccessGrant.from_dict(item)
+            for item in unwrap_list(
+                res, "access_grants", "/access_grants/unmanaged/list"
+            )
+        ]
 
     @route_metadata(
         path="/access_grants/unmanaged/update",
@@ -291,7 +300,9 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
         res = await self.client.get("/access_grants/unmanaged/get", params=params)
 
-        return UnmanagedAccessGrant.from_dict(res["access_grant"])
+        return UnmanagedAccessGrant.from_dict(
+            unwrap(res, "access_grant", "/access_grants/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_grants/unmanaged/list",
@@ -340,7 +351,12 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
         res = await self.client.get("/access_grants/unmanaged/list", params=params)
 
-        return [UnmanagedAccessGrant.from_dict(item) for item in res["access_grants"]]
+        return [
+            UnmanagedAccessGrant.from_dict(item)
+            for item in unwrap_list(
+                res, "access_grants", "/access_grants/unmanaged/list"
+            )
+        ]
 
     @route_metadata(
         path="/access_grants/unmanaged/update",

--- a/seam/routes/access_methods.py
+++ b/seam/routes/access_methods.py
@@ -14,6 +14,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessMethods(abc.ABC):
@@ -439,7 +441,9 @@ class AccessMethods(AbstractAccessMethods):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/assign_card")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -527,7 +531,9 @@ class AccessMethods(AbstractAccessMethods):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/encode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -554,7 +560,9 @@ class AccessMethods(AbstractAccessMethods):
 
         res = self.client.get("/access_methods/get", params=params)
 
-        return AccessMethod.from_dict(res["access_method"])
+        return AccessMethod.from_dict(
+            unwrap(res, "access_method", "/access_methods/get")
+        )
 
     @route_metadata(
         path="/access_methods/get_related",
@@ -621,7 +629,7 @@ class AccessMethods(AbstractAccessMethods):
 
         res = self.client.get("/access_methods/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/access_methods/get_related"))
 
     @route_metadata(
         path="/access_methods/list", has_required_parameters=True, has_pagination=True
@@ -685,7 +693,10 @@ class AccessMethods(AbstractAccessMethods):
 
         res = self.client.get("/access_methods/list", params=params)
 
-        return [AccessMethod.from_dict(item) for item in res["access_methods"]]
+        return [
+            AccessMethod.from_dict(item)
+            for item in unwrap_list(res, "access_methods", "/access_methods/list")
+        ]
 
     @route_metadata(
         path="/access_methods/unlock_door",
@@ -732,7 +743,9 @@ class AccessMethods(AbstractAccessMethods):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/unlock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -792,7 +805,9 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/assign_card")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -880,7 +895,9 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/encode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -907,7 +924,9 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         res = await self.client.get("/access_methods/get", params=params)
 
-        return AccessMethod.from_dict(res["access_method"])
+        return AccessMethod.from_dict(
+            unwrap(res, "access_method", "/access_methods/get")
+        )
 
     @route_metadata(
         path="/access_methods/get_related",
@@ -974,7 +993,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         res = await self.client.get("/access_methods/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/access_methods/get_related"))
 
     @route_metadata(
         path="/access_methods/list", has_required_parameters=True, has_pagination=True
@@ -1038,7 +1057,10 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         res = await self.client.get("/access_methods/list", params=params)
 
-        return [AccessMethod.from_dict(item) for item in res["access_methods"]]
+        return [
+            AccessMethod.from_dict(item)
+            for item in unwrap_list(res, "access_methods", "/access_methods/list")
+        ]
 
     @route_metadata(
         path="/access_methods/unlock_door",
@@ -1085,6 +1107,8 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/access_methods/unlock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/access_methods_unmanaged.py
+++ b/seam/routes/access_methods_unmanaged.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import UnmanagedAccessMethod
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAccessMethodsUnmanaged(abc.ABC):
@@ -111,7 +113,9 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
         res = self.client.get("/access_methods/unmanaged/get", params=params)
 
-        return UnmanagedAccessMethod.from_dict(res["access_method"])
+        return UnmanagedAccessMethod.from_dict(
+            unwrap(res, "access_method", "/access_methods/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_methods/unmanaged/list",
@@ -157,7 +161,12 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
         res = self.client.get("/access_methods/unmanaged/list", params=params)
 
-        return [UnmanagedAccessMethod.from_dict(item) for item in res["access_methods"]]
+        return [
+            UnmanagedAccessMethod.from_dict(item)
+            for item in unwrap_list(
+                res, "access_methods", "/access_methods/unmanaged/list"
+            )
+        ]
 
 
 class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
@@ -190,7 +199,9 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
         res = await self.client.get("/access_methods/unmanaged/get", params=params)
 
-        return UnmanagedAccessMethod.from_dict(res["access_method"])
+        return UnmanagedAccessMethod.from_dict(
+            unwrap(res, "access_method", "/access_methods/unmanaged/get")
+        )
 
     @route_metadata(
         path="/access_methods/unmanaged/list",
@@ -236,4 +247,9 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
         res = await self.client.get("/access_methods/unmanaged/list", params=params)
 
-        return [UnmanagedAccessMethod.from_dict(item) for item in res["access_methods"]]
+        return [
+            UnmanagedAccessMethod.from_dict(item)
+            for item in unwrap_list(
+                res, "access_methods", "/access_methods/unmanaged/list"
+            )
+        ]

--- a/seam/routes/acs_access_groups.py
+++ b/seam/routes/acs_access_groups.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import AcsAccessGroup, AcsEntrance, AcsUser
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsAccessGroups(abc.ABC):
@@ -313,7 +315,9 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         res = self.client.get("/acs/access_groups/get", params=params)
 
-        return AcsAccessGroup.from_dict(res["acs_access_group"])
+        return AcsAccessGroup.from_dict(
+            unwrap(res, "acs_access_group", "/acs/access_groups/get")
+        )
 
     @route_metadata(
         path="/acs/access_groups/list",
@@ -352,7 +356,10 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         res = self.client.get("/acs/access_groups/list", params=params)
 
-        return [AcsAccessGroup.from_dict(item) for item in res["acs_access_groups"]]
+        return [
+            AcsAccessGroup.from_dict(item)
+            for item in unwrap_list(res, "acs_access_groups", "/acs/access_groups/list")
+        ]
 
     @route_metadata(
         path="/acs/access_groups/list_accessible_entrances",
@@ -383,7 +390,12 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
             "/acs/access_groups/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/access_groups/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/access_groups/list_users",
@@ -410,7 +422,10 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         res = self.client.get("/acs/access_groups/list_users", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/acs/access_groups/list_users")
+        ]
 
     @route_metadata(
         path="/acs/access_groups/remove_user",
@@ -546,7 +561,9 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         res = await self.client.get("/acs/access_groups/get", params=params)
 
-        return AcsAccessGroup.from_dict(res["acs_access_group"])
+        return AcsAccessGroup.from_dict(
+            unwrap(res, "acs_access_group", "/acs/access_groups/get")
+        )
 
     @route_metadata(
         path="/acs/access_groups/list",
@@ -585,7 +602,10 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         res = await self.client.get("/acs/access_groups/list", params=params)
 
-        return [AcsAccessGroup.from_dict(item) for item in res["acs_access_groups"]]
+        return [
+            AcsAccessGroup.from_dict(item)
+            for item in unwrap_list(res, "acs_access_groups", "/acs/access_groups/list")
+        ]
 
     @route_metadata(
         path="/acs/access_groups/list_accessible_entrances",
@@ -616,7 +636,12 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
             "/acs/access_groups/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/access_groups/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/access_groups/list_users",
@@ -643,7 +668,10 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         res = await self.client.get("/acs/access_groups/list_users", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/acs/access_groups/list_users")
+        ]
 
     @route_metadata(
         path="/acs/access_groups/remove_user",

--- a/seam/routes/acs_credentials.py
+++ b/seam/routes/acs_credentials.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import AcsCredential, AcsEntrance
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsCredentials(abc.ABC):
@@ -497,7 +499,9 @@ class AcsCredentials(AbstractAcsCredentials):
 
         res = self.client.post("/acs/credentials/create", json=json_payload)
 
-        return AcsCredential.from_dict(res["acs_credential"])
+        return AcsCredential.from_dict(
+            unwrap(res, "acs_credential", "/acs/credentials/create")
+        )
 
     @route_metadata(
         path="/acs/credentials/delete",
@@ -547,7 +551,9 @@ class AcsCredentials(AbstractAcsCredentials):
 
         res = self.client.get("/acs/credentials/get", params=params)
 
-        return AcsCredential.from_dict(res["acs_credential"])
+        return AcsCredential.from_dict(
+            unwrap(res, "acs_credential", "/acs/credentials/get")
+        )
 
     @route_metadata(
         path="/acs/credentials/list", has_required_parameters=False, has_pagination=True
@@ -604,7 +610,10 @@ class AcsCredentials(AbstractAcsCredentials):
 
         res = self.client.get("/acs/credentials/list", params=params)
 
-        return [AcsCredential.from_dict(item) for item in res["acs_credentials"]]
+        return [
+            AcsCredential.from_dict(item)
+            for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
+        ]
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",
@@ -633,7 +642,12 @@ class AcsCredentials(AbstractAcsCredentials):
             "/acs/credentials/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/credentials/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/credentials/unassign",
@@ -851,7 +865,9 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         res = await self.client.post("/acs/credentials/create", json=json_payload)
 
-        return AcsCredential.from_dict(res["acs_credential"])
+        return AcsCredential.from_dict(
+            unwrap(res, "acs_credential", "/acs/credentials/create")
+        )
 
     @route_metadata(
         path="/acs/credentials/delete",
@@ -901,7 +917,9 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         res = await self.client.get("/acs/credentials/get", params=params)
 
-        return AcsCredential.from_dict(res["acs_credential"])
+        return AcsCredential.from_dict(
+            unwrap(res, "acs_credential", "/acs/credentials/get")
+        )
 
     @route_metadata(
         path="/acs/credentials/list", has_required_parameters=False, has_pagination=True
@@ -958,7 +976,10 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         res = await self.client.get("/acs/credentials/list", params=params)
 
-        return [AcsCredential.from_dict(item) for item in res["acs_credentials"]]
+        return [
+            AcsCredential.from_dict(item)
+            for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
+        ]
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",
@@ -989,7 +1010,12 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
             "/acs/credentials/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/credentials/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/credentials/unassign",

--- a/seam/routes/acs_encoders.py
+++ b/seam/routes/acs_encoders.py
@@ -14,6 +14,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsEncoders(abc.ABC):
@@ -308,7 +310,9 @@ class AcsEncoders(AbstractAcsEncoders):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/encode_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -333,7 +337,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
         res = self.client.get("/acs/encoders/get", params=params)
 
-        return AcsEncoder.from_dict(res["acs_encoder"])
+        return AcsEncoder.from_dict(unwrap(res, "acs_encoder", "/acs/encoders/get"))
 
     @route_metadata(
         path="/acs/encoders/list", has_required_parameters=False, has_pagination=True
@@ -375,7 +379,10 @@ class AcsEncoders(AbstractAcsEncoders):
 
         res = self.client.get("/acs/encoders/list", params=params)
 
-        return [AcsEncoder.from_dict(item) for item in res["acs_encoders"]]
+        return [
+            AcsEncoder.from_dict(item)
+            for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
+        ]
 
     @route_metadata(
         path="/acs/encoders/scan_credential",
@@ -422,7 +429,9 @@ class AcsEncoders(AbstractAcsEncoders):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/scan_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -483,7 +492,9 @@ class AcsEncoders(AbstractAcsEncoders):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/scan_to_assign_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -550,7 +561,9 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/encode_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -575,7 +588,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         res = await self.client.get("/acs/encoders/get", params=params)
 
-        return AcsEncoder.from_dict(res["acs_encoder"])
+        return AcsEncoder.from_dict(unwrap(res, "acs_encoder", "/acs/encoders/get"))
 
     @route_metadata(
         path="/acs/encoders/list", has_required_parameters=False, has_pagination=True
@@ -617,7 +630,10 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         res = await self.client.get("/acs/encoders/list", params=params)
 
-        return [AcsEncoder.from_dict(item) for item in res["acs_encoders"]]
+        return [
+            AcsEncoder.from_dict(item)
+            for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
+        ]
 
     @route_metadata(
         path="/acs/encoders/scan_credential",
@@ -664,7 +680,9 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/scan_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -725,6 +743,8 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/encoders/scan_to_assign_credential")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/acs_entrances.py
+++ b/seam/routes/acs_entrances.py
@@ -13,6 +13,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsEntrances(abc.ABC):
@@ -273,7 +275,7 @@ class AcsEntrances(AbstractAcsEntrances):
 
         res = self.client.get("/acs/entrances/get", params=params)
 
-        return AcsEntrance.from_dict(res["acs_entrance"])
+        return AcsEntrance.from_dict(unwrap(res, "acs_entrance", "/acs/entrances/get"))
 
     @route_metadata(
         path="/acs/entrances/grant_access",
@@ -384,7 +386,10 @@ class AcsEntrances(AbstractAcsEntrances):
 
         res = self.client.get("/acs/entrances/list", params=params)
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
+        ]
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",
@@ -422,7 +427,12 @@ class AcsEntrances(AbstractAcsEntrances):
             "/acs/entrances/list_credentials_with_access", params=params
         )
 
-        return [AcsCredential.from_dict(item) for item in res["acs_credentials"]]
+        return [
+            AcsCredential.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_credentials", "/acs/entrances/list_credentials_with_access"
+            )
+        ]
 
     @route_metadata(
         path="/acs/entrances/unlock", has_required_parameters=True, has_pagination=False
@@ -467,7 +477,9 @@ class AcsEntrances(AbstractAcsEntrances):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/entrances/unlock")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -500,7 +512,7 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         res = await self.client.get("/acs/entrances/get", params=params)
 
-        return AcsEntrance.from_dict(res["acs_entrance"])
+        return AcsEntrance.from_dict(unwrap(res, "acs_entrance", "/acs/entrances/get"))
 
     @route_metadata(
         path="/acs/entrances/grant_access",
@@ -611,7 +623,10 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         res = await self.client.get("/acs/entrances/list", params=params)
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
+        ]
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",
@@ -649,7 +664,12 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
             "/acs/entrances/list_credentials_with_access", params=params
         )
 
-        return [AcsCredential.from_dict(item) for item in res["acs_credentials"]]
+        return [
+            AcsCredential.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_credentials", "/acs/entrances/list_credentials_with_access"
+            )
+        ]
 
     @route_metadata(
         path="/acs/entrances/unlock", has_required_parameters=True, has_pagination=False
@@ -694,6 +714,8 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/acs/entrances/unlock")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/acs_systems.py
+++ b/seam/routes/acs_systems.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import AcsSystem
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsSystems(abc.ABC):
@@ -169,7 +171,7 @@ class AcsSystems(AbstractAcsSystems):
 
         res = self.client.get("/acs/systems/get", params=params)
 
-        return AcsSystem.from_dict(res["acs_system"])
+        return AcsSystem.from_dict(unwrap(res, "acs_system", "/acs/systems/get"))
 
     @route_metadata(
         path="/acs/systems/list", has_required_parameters=False, has_pagination=False
@@ -203,7 +205,10 @@ class AcsSystems(AbstractAcsSystems):
 
         res = self.client.get("/acs/systems/list", params=params)
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(res, "acs_systems", "/acs/systems/list")
+        ]
 
     @route_metadata(
         path="/acs/systems/list_compatible_credential_manager_acs_systems",
@@ -236,7 +241,14 @@ class AcsSystems(AbstractAcsSystems):
             "/acs/systems/list_compatible_credential_manager_acs_systems", params=params
         )
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(
+                res,
+                "acs_systems",
+                "/acs/systems/list_compatible_credential_manager_acs_systems",
+            )
+        ]
 
     @route_metadata(
         path="/acs/systems/report_devices",
@@ -304,7 +316,7 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
         res = await self.client.get("/acs/systems/get", params=params)
 
-        return AcsSystem.from_dict(res["acs_system"])
+        return AcsSystem.from_dict(unwrap(res, "acs_system", "/acs/systems/get"))
 
     @route_metadata(
         path="/acs/systems/list", has_required_parameters=False, has_pagination=False
@@ -338,7 +350,10 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
         res = await self.client.get("/acs/systems/list", params=params)
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(res, "acs_systems", "/acs/systems/list")
+        ]
 
     @route_metadata(
         path="/acs/systems/list_compatible_credential_manager_acs_systems",
@@ -371,7 +386,14 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
             "/acs/systems/list_compatible_credential_manager_acs_systems", params=params
         )
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(
+                res,
+                "acs_systems",
+                "/acs/systems/list_compatible_credential_manager_acs_systems",
+            )
+        ]
 
     @route_metadata(
         path="/acs/systems/report_devices",

--- a/seam/routes/acs_users.py
+++ b/seam/routes/acs_users.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import AcsUser, AcsEntrance
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractAcsUsers(abc.ABC):
@@ -622,7 +624,7 @@ class AcsUsers(AbstractAcsUsers):
 
         res = self.client.post("/acs/users/create", json=json_payload)
 
-        return AcsUser.from_dict(res["acs_user"])
+        return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/create"))
 
     @route_metadata(
         path="/acs/users/delete", has_required_parameters=True, has_pagination=False
@@ -694,7 +696,7 @@ class AcsUsers(AbstractAcsUsers):
 
         res = self.client.get("/acs/users/get", params=params)
 
-        return AcsUser.from_dict(res["acs_user"])
+        return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/get"))
 
     @route_metadata(
         path="/acs/users/list", has_required_parameters=False, has_pagination=True
@@ -751,7 +753,10 @@ class AcsUsers(AbstractAcsUsers):
 
         res = self.client.get("/acs/users/list", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/acs/users/list")
+        ]
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",
@@ -792,7 +797,12 @@ class AcsUsers(AbstractAcsUsers):
 
         res = self.client.get("/acs/users/list_accessible_entrances", params=params)
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/users/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/users/remove_from_access_group",
@@ -1108,7 +1118,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
         res = await self.client.post("/acs/users/create", json=json_payload)
 
-        return AcsUser.from_dict(res["acs_user"])
+        return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/create"))
 
     @route_metadata(
         path="/acs/users/delete", has_required_parameters=True, has_pagination=False
@@ -1180,7 +1190,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
         res = await self.client.get("/acs/users/get", params=params)
 
-        return AcsUser.from_dict(res["acs_user"])
+        return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/get"))
 
     @route_metadata(
         path="/acs/users/list", has_required_parameters=False, has_pagination=True
@@ -1237,7 +1247,10 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
         res = await self.client.get("/acs/users/list", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/acs/users/list")
+        ]
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",
@@ -1280,7 +1293,12 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
             "/acs/users/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/acs/users/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/acs/users/remove_from_access_group",

--- a/seam/routes/action_attempts.py
+++ b/seam/routes/action_attempts.py
@@ -8,6 +8,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractActionAttempts(abc.ABC):
@@ -139,7 +141,9 @@ class ActionAttempts(AbstractActionAttempts):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/action_attempts/get")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -178,7 +182,10 @@ class ActionAttempts(AbstractActionAttempts):
 
         res = self.client.get("/action_attempts/list", params=params)
 
-        return [action_attempt_from_dict(item) for item in res["action_attempts"]]
+        return [
+            action_attempt_from_dict(item)
+            for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
+        ]
 
 
 class AsyncActionAttempts(AbstractAsyncActionAttempts):
@@ -224,7 +231,9 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/action_attempts/get")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -263,4 +272,7 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
 
         res = await self.client.get("/action_attempts/list", params=params)
 
-        return [action_attempt_from_dict(item) for item in res["action_attempts"]]
+        return [
+            action_attempt_from_dict(item)
+            for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
+        ]

--- a/seam/routes/client_sessions.py
+++ b/seam/routes/client_sessions.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import ClientSession
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractClientSessions(abc.ABC):
@@ -376,7 +378,9 @@ class ClientSessions(AbstractClientSessions):
 
         res = self.client.put("/client_sessions/create", json=json_payload)
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/create")
+        )
 
     @route_metadata(
         path="/client_sessions/delete",
@@ -428,7 +432,9 @@ class ClientSessions(AbstractClientSessions):
 
         res = self.client.get("/client_sessions/get", params=params)
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/get")
+        )
 
     @route_metadata(
         path="/client_sessions/get_or_create",
@@ -477,7 +483,9 @@ class ClientSessions(AbstractClientSessions):
 
         res = self.client.post("/client_sessions/get_or_create", json=json_payload)
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/get_or_create")
+        )
 
     @route_metadata(
         path="/client_sessions/grant_access",
@@ -575,7 +583,10 @@ class ClientSessions(AbstractClientSessions):
 
         res = self.client.get("/client_sessions/list", params=params)
 
-        return [ClientSession.from_dict(item) for item in res["client_sessions"]]
+        return [
+            ClientSession.from_dict(item)
+            for item in unwrap_list(res, "client_sessions", "/client_sessions/list")
+        ]
 
     @route_metadata(
         path="/client_sessions/revoke",
@@ -667,7 +678,9 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
         res = await self.client.put("/client_sessions/create", json=json_payload)
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/create")
+        )
 
     @route_metadata(
         path="/client_sessions/delete",
@@ -719,7 +732,9 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
         res = await self.client.get("/client_sessions/get", params=params)
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/get")
+        )
 
     @route_metadata(
         path="/client_sessions/get_or_create",
@@ -770,7 +785,9 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
             "/client_sessions/get_or_create", json=json_payload
         )
 
-        return ClientSession.from_dict(res["client_session"])
+        return ClientSession.from_dict(
+            unwrap(res, "client_session", "/client_sessions/get_or_create")
+        )
 
     @route_metadata(
         path="/client_sessions/grant_access",
@@ -868,7 +885,10 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
         res = await self.client.get("/client_sessions/list", params=params)
 
-        return [ClientSession.from_dict(item) for item in res["client_sessions"]]
+        return [
+            ClientSession.from_dict(item)
+            for item in unwrap_list(res, "client_sessions", "/client_sessions/list")
+        ]
 
     @route_metadata(
         path="/client_sessions/revoke",

--- a/seam/routes/connect_webviews.py
+++ b/seam/routes/connect_webviews.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import ConnectWebview
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractConnectWebviews(abc.ABC):
@@ -561,7 +563,9 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         res = self.client.post("/connect_webviews/create", json=json_payload)
 
-        return ConnectWebview.from_dict(res["connect_webview"])
+        return ConnectWebview.from_dict(
+            unwrap(res, "connect_webview", "/connect_webviews/create")
+        )
 
     @route_metadata(
         path="/connect_webviews/delete",
@@ -615,7 +619,9 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         res = self.client.get("/connect_webviews/get", params=params)
 
-        return ConnectWebview.from_dict(res["connect_webview"])
+        return ConnectWebview.from_dict(
+            unwrap(res, "connect_webview", "/connect_webviews/get")
+        )
 
     @route_metadata(
         path="/connect_webviews/list",
@@ -664,7 +670,10 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         res = self.client.get("/connect_webviews/list", params=params)
 
-        return [ConnectWebview.from_dict(item) for item in res["connect_webviews"]]
+        return [
+            ConnectWebview.from_dict(item)
+            for item in unwrap_list(res, "connect_webviews", "/connect_webviews/list")
+        ]
 
 
 class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
@@ -838,7 +847,9 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         res = await self.client.post("/connect_webviews/create", json=json_payload)
 
-        return ConnectWebview.from_dict(res["connect_webview"])
+        return ConnectWebview.from_dict(
+            unwrap(res, "connect_webview", "/connect_webviews/create")
+        )
 
     @route_metadata(
         path="/connect_webviews/delete",
@@ -892,7 +903,9 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         res = await self.client.get("/connect_webviews/get", params=params)
 
-        return ConnectWebview.from_dict(res["connect_webview"])
+        return ConnectWebview.from_dict(
+            unwrap(res, "connect_webview", "/connect_webviews/get")
+        )
 
     @route_metadata(
         path="/connect_webviews/list",
@@ -941,4 +954,7 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         res = await self.client.get("/connect_webviews/list", params=params)
 
-        return [ConnectWebview.from_dict(item) for item in res["connect_webviews"]]
+        return [
+            ConnectWebview.from_dict(item)
+            for item in unwrap_list(res, "connect_webviews", "/connect_webviews/list")
+        ]

--- a/seam/routes/connected_accounts.py
+++ b/seam/routes/connected_accounts.py
@@ -10,6 +10,8 @@ from .connected_accounts_simulate import (
     AbstractAsyncConnectedAccountsSimulate,
     AsyncConnectedAccountsSimulate,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractConnectedAccounts(abc.ABC):
@@ -302,7 +304,9 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
         res = self.client.get("/connected_accounts/get", params=params)
 
-        return ConnectedAccount.from_dict(res["connected_account"])
+        return ConnectedAccount.from_dict(
+            unwrap(res, "connected_account", "/connected_accounts/get")
+        )
 
     @route_metadata(
         path="/connected_accounts/list",
@@ -356,7 +360,12 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
         res = self.client.get("/connected_accounts/list", params=params)
 
-        return [ConnectedAccount.from_dict(item) for item in res["connected_accounts"]]
+        return [
+            ConnectedAccount.from_dict(item)
+            for item in unwrap_list(
+                res, "connected_accounts", "/connected_accounts/list"
+            )
+        ]
 
     @route_metadata(
         path="/connected_accounts/sync",
@@ -518,7 +527,9 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
         res = await self.client.get("/connected_accounts/get", params=params)
 
-        return ConnectedAccount.from_dict(res["connected_account"])
+        return ConnectedAccount.from_dict(
+            unwrap(res, "connected_account", "/connected_accounts/get")
+        )
 
     @route_metadata(
         path="/connected_accounts/list",
@@ -572,7 +583,12 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
         res = await self.client.get("/connected_accounts/list", params=params)
 
-        return [ConnectedAccount.from_dict(item) for item in res["connected_accounts"]]
+        return [
+            ConnectedAccount.from_dict(item)
+            for item in unwrap_list(
+                res, "connected_accounts", "/connected_accounts/list"
+            )
+        ]
 
     @route_metadata(
         path="/connected_accounts/sync",

--- a/seam/routes/customers.py
+++ b/seam/routes/customers.py
@@ -3,6 +3,7 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import CustomerPortal
+from ..response import unwrap
 
 
 class AbstractCustomers(abc.ABC):
@@ -485,7 +486,9 @@ class Customers(AbstractCustomers):
 
         res = self.client.post("/customers/create_portal", json=json_payload)
 
-        return CustomerPortal.from_dict(res["customer_portal"])
+        return CustomerPortal.from_dict(
+            unwrap(res, "customer_portal", "/customers/create_portal")
+        )
 
     @route_metadata(
         path="/customers/delete_data",
@@ -813,7 +816,9 @@ class AsyncCustomers(AbstractAsyncCustomers):
 
         res = await self.client.post("/customers/create_portal", json=json_payload)
 
-        return CustomerPortal.from_dict(res["customer_portal"])
+        return CustomerPortal.from_dict(
+            unwrap(res, "customer_portal", "/customers/create_portal")
+        )
 
     @route_metadata(
         path="/customers/delete_data",

--- a/seam/routes/devices.py
+++ b/seam/routes/devices.py
@@ -16,6 +16,8 @@ from .devices_unmanaged import (
     AbstractAsyncDevicesUnmanaged,
     AsyncDevicesUnmanaged,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractDevices(abc.ABC):
@@ -670,7 +672,7 @@ class Devices(AbstractDevices):
 
         res = self.client.get("/devices/get", params=params)
 
-        return Device.from_dict(res["device"])
+        return Device.from_dict(unwrap(res, "device", "/devices/get"))
 
     @route_metadata(
         path="/devices/list", has_required_parameters=False, has_pagination=True
@@ -916,7 +918,10 @@ class Devices(AbstractDevices):
 
         res = self.client.get("/devices/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/devices/list")
+        ]
 
     @route_metadata(
         path="/devices/list_device_providers",
@@ -955,7 +960,12 @@ class Devices(AbstractDevices):
 
         res = self.client.get("/devices/list_device_providers", params=params)
 
-        return [DeviceProvider.from_dict(item) for item in res["device_providers"]]
+        return [
+            DeviceProvider.from_dict(item)
+            for item in unwrap_list(
+                res, "device_providers", "/devices/list_device_providers"
+            )
+        ]
 
     @route_metadata(
         path="/devices/report_provider_metadata",
@@ -1081,7 +1091,7 @@ class AsyncDevices(AbstractAsyncDevices):
 
         res = await self.client.get("/devices/get", params=params)
 
-        return Device.from_dict(res["device"])
+        return Device.from_dict(unwrap(res, "device", "/devices/get"))
 
     @route_metadata(
         path="/devices/list", has_required_parameters=False, has_pagination=True
@@ -1327,7 +1337,10 @@ class AsyncDevices(AbstractAsyncDevices):
 
         res = await self.client.get("/devices/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/devices/list")
+        ]
 
     @route_metadata(
         path="/devices/list_device_providers",
@@ -1366,7 +1379,12 @@ class AsyncDevices(AbstractAsyncDevices):
 
         res = await self.client.get("/devices/list_device_providers", params=params)
 
-        return [DeviceProvider.from_dict(item) for item in res["device_providers"]]
+        return [
+            DeviceProvider.from_dict(item)
+            for item in unwrap_list(
+                res, "device_providers", "/devices/list_device_providers"
+            )
+        ]
 
     @route_metadata(
         path="/devices/report_provider_metadata",

--- a/seam/routes/devices_unmanaged.py
+++ b/seam/routes/devices_unmanaged.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import UnmanagedDevice
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractDevicesUnmanaged(abc.ABC):
@@ -526,7 +528,9 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
         res = self.client.get("/devices/unmanaged/get", params=params)
 
-        return UnmanagedDevice.from_dict(res["device"])
+        return UnmanagedDevice.from_dict(
+            unwrap(res, "device", "/devices/unmanaged/get")
+        )
 
     @route_metadata(
         path="/devices/unmanaged/list",
@@ -756,7 +760,10 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
         res = self.client.get("/devices/unmanaged/list", params=params)
 
-        return [UnmanagedDevice.from_dict(item) for item in res["devices"]]
+        return [
+            UnmanagedDevice.from_dict(item)
+            for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
+        ]
 
     @route_metadata(
         path="/devices/unmanaged/update",
@@ -840,7 +847,9 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
         res = await self.client.get("/devices/unmanaged/get", params=params)
 
-        return UnmanagedDevice.from_dict(res["device"])
+        return UnmanagedDevice.from_dict(
+            unwrap(res, "device", "/devices/unmanaged/get")
+        )
 
     @route_metadata(
         path="/devices/unmanaged/list",
@@ -1070,7 +1079,10 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
         res = await self.client.get("/devices/unmanaged/list", params=params)
 
-        return [UnmanagedDevice.from_dict(item) for item in res["devices"]]
+        return [
+            UnmanagedDevice.from_dict(item)
+            for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
+        ]
 
     @route_metadata(
         path="/devices/unmanaged/update",

--- a/seam/routes/events.py
+++ b/seam/routes/events.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import SeamEvent, seam_event_from_dict
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractEvents(abc.ABC):
@@ -757,7 +759,7 @@ class Events(AbstractEvents):
 
         res = self.client.get("/events/get", params=params)
 
-        return seam_event_from_dict(res["event"])
+        return seam_event_from_dict(unwrap(res, "event", "/events/get"))
 
     @route_metadata(
         path="/events/list", has_required_parameters=True, has_pagination=False
@@ -1155,7 +1157,10 @@ class Events(AbstractEvents):
 
         res = self.client.get("/events/list", params=params)
 
-        return [seam_event_from_dict(item) for item in res["events"]]
+        return [
+            seam_event_from_dict(item)
+            for item in unwrap_list(res, "events", "/events/list")
+        ]
 
 
 class AsyncEvents(AbstractAsyncEvents):
@@ -1198,7 +1203,7 @@ class AsyncEvents(AbstractAsyncEvents):
 
         res = await self.client.get("/events/get", params=params)
 
-        return seam_event_from_dict(res["event"])
+        return seam_event_from_dict(unwrap(res, "event", "/events/get"))
 
     @route_metadata(
         path="/events/list", has_required_parameters=True, has_pagination=False
@@ -1596,4 +1601,7 @@ class AsyncEvents(AbstractAsyncEvents):
 
         res = await self.client.get("/events/list", params=params)
 
-        return [seam_event_from_dict(item) for item in res["events"]]
+        return [
+            seam_event_from_dict(item)
+            for item in unwrap_list(res, "events", "/events/list")
+        ]

--- a/seam/routes/instant_keys.py
+++ b/seam/routes/instant_keys.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import InstantKey
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractInstantKeys(abc.ABC):
@@ -141,7 +143,7 @@ class InstantKeys(AbstractInstantKeys):
 
         res = self.client.get("/instant_keys/get", params=params)
 
-        return InstantKey.from_dict(res["instant_key"])
+        return InstantKey.from_dict(unwrap(res, "instant_key", "/instant_keys/get"))
 
     @route_metadata(
         path="/instant_keys/list", has_required_parameters=False, has_pagination=False
@@ -159,7 +161,10 @@ class InstantKeys(AbstractInstantKeys):
 
         res = self.client.get("/instant_keys/list", params=params)
 
-        return [InstantKey.from_dict(item) for item in res["instant_keys"]]
+        return [
+            InstantKey.from_dict(item)
+            for item in unwrap_list(res, "instant_keys", "/instant_keys/list")
+        ]
 
 
 class AsyncInstantKeys(AbstractAsyncInstantKeys):
@@ -220,7 +225,7 @@ class AsyncInstantKeys(AbstractAsyncInstantKeys):
 
         res = await self.client.get("/instant_keys/get", params=params)
 
-        return InstantKey.from_dict(res["instant_key"])
+        return InstantKey.from_dict(unwrap(res, "instant_key", "/instant_keys/get"))
 
     @route_metadata(
         path="/instant_keys/list", has_required_parameters=False, has_pagination=False
@@ -238,4 +243,7 @@ class AsyncInstantKeys(AbstractAsyncInstantKeys):
 
         res = await self.client.get("/instant_keys/list", params=params)
 
-        return [InstantKey.from_dict(item) for item in res["instant_keys"]]
+        return [
+            InstantKey.from_dict(item)
+            for item in unwrap_list(res, "instant_keys", "/instant_keys/list")
+        ]

--- a/seam/routes/locks.py
+++ b/seam/routes/locks.py
@@ -13,6 +13,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractLocks(abc.ABC):
@@ -515,7 +517,9 @@ class Locks(AbstractLocks):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/configure_auto_lock")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -549,7 +553,7 @@ class Locks(AbstractLocks):
 
         res = self.client.get("/locks/get", params=params)
 
-        return Device.from_dict(res["device"])
+        return Device.from_dict(unwrap(res, "device", "/locks/get"))
 
     @route_metadata(
         path="/locks/list", has_required_parameters=False, has_pagination=False
@@ -702,7 +706,10 @@ class Locks(AbstractLocks):
 
         res = self.client.get("/locks/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/locks/list")
+        ]
 
     @route_metadata(
         path="/locks/lock_door", has_required_parameters=True, has_pagination=False
@@ -740,7 +747,9 @@ class Locks(AbstractLocks):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/lock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -782,7 +791,9 @@ class Locks(AbstractLocks):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/unlock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -847,7 +858,9 @@ class AsyncLocks(AbstractAsyncLocks):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/configure_auto_lock")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -881,7 +894,7 @@ class AsyncLocks(AbstractAsyncLocks):
 
         res = await self.client.get("/locks/get", params=params)
 
-        return Device.from_dict(res["device"])
+        return Device.from_dict(unwrap(res, "device", "/locks/get"))
 
     @route_metadata(
         path="/locks/list", has_required_parameters=False, has_pagination=False
@@ -1034,7 +1047,10 @@ class AsyncLocks(AbstractAsyncLocks):
 
         res = await self.client.get("/locks/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/locks/list")
+        ]
 
     @route_metadata(
         path="/locks/lock_door", has_required_parameters=True, has_pagination=False
@@ -1072,7 +1088,9 @@ class AsyncLocks(AbstractAsyncLocks):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/lock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1114,6 +1132,8 @@ class AsyncLocks(AbstractAsyncLocks):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/unlock_door")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/locks_simulate.py
+++ b/seam/routes/locks_simulate.py
@@ -7,6 +7,7 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
 
 
 class AbstractLocksSimulate(abc.ABC):
@@ -143,7 +144,9 @@ class LocksSimulate(AbstractLocksSimulate):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/simulate/keypad_code_entry")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -189,7 +192,9 @@ class LocksSimulate(AbstractLocksSimulate):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/simulate/manual_lock_via_keypad")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -246,7 +251,9 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/simulate/keypad_code_entry")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -292,6 +299,8 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/locks/simulate/manual_lock_via_keypad")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/noise_sensors.py
+++ b/seam/routes/noise_sensors.py
@@ -15,6 +15,7 @@ from .noise_sensors_simulate import (
     AbstractAsyncNoiseSensorsSimulate,
     AsyncNoiseSensorsSimulate,
 )
+from ..response import unwrap_list
 
 
 class AbstractNoiseSensors(abc.ABC):
@@ -173,7 +174,10 @@ class NoiseSensors(AbstractNoiseSensors):
 
         res = self.client.get("/noise_sensors/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/noise_sensors/list")
+        ]
 
 
 class AsyncNoiseSensors(AbstractAsyncNoiseSensors):
@@ -242,4 +246,7 @@ class AsyncNoiseSensors(AbstractAsyncNoiseSensors):
 
         res = await self.client.get("/noise_sensors/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/noise_sensors/list")
+        ]

--- a/seam/routes/noise_sensors_noise_thresholds.py
+++ b/seam/routes/noise_sensors_noise_thresholds.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import NoiseThreshold
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
@@ -260,7 +262,9 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
             "/noise_sensors/noise_thresholds/create", json=json_payload
         )
 
-        return NoiseThreshold.from_dict(res["noise_threshold"])
+        return NoiseThreshold.from_dict(
+            unwrap(res, "noise_threshold", "/noise_sensors/noise_thresholds/create")
+        )
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/delete",
@@ -316,7 +320,9 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         res = self.client.get("/noise_sensors/noise_thresholds/get", params=params)
 
-        return NoiseThreshold.from_dict(res["noise_threshold"])
+        return NoiseThreshold.from_dict(
+            unwrap(res, "noise_threshold", "/noise_sensors/noise_thresholds/get")
+        )
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/list",
@@ -343,7 +349,12 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         res = self.client.get("/noise_sensors/noise_thresholds/list", params=params)
 
-        return [NoiseThreshold.from_dict(item) for item in res["noise_thresholds"]]
+        return [
+            NoiseThreshold.from_dict(item)
+            for item in unwrap_list(
+                res, "noise_thresholds", "/noise_sensors/noise_thresholds/list"
+            )
+        ]
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/update",
@@ -466,7 +477,9 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
             "/noise_sensors/noise_thresholds/create", json=json_payload
         )
 
-        return NoiseThreshold.from_dict(res["noise_threshold"])
+        return NoiseThreshold.from_dict(
+            unwrap(res, "noise_threshold", "/noise_sensors/noise_thresholds/create")
+        )
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/delete",
@@ -526,7 +539,9 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
             "/noise_sensors/noise_thresholds/get", params=params
         )
 
-        return NoiseThreshold.from_dict(res["noise_threshold"])
+        return NoiseThreshold.from_dict(
+            unwrap(res, "noise_threshold", "/noise_sensors/noise_thresholds/get")
+        )
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/list",
@@ -555,7 +570,12 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
             "/noise_sensors/noise_thresholds/list", params=params
         )
 
-        return [NoiseThreshold.from_dict(item) for item in res["noise_thresholds"]]
+        return [
+            NoiseThreshold.from_dict(item)
+            for item in unwrap_list(
+                res, "noise_thresholds", "/noise_sensors/noise_thresholds/list"
+            )
+        ]
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/update",

--- a/seam/routes/phones.py
+++ b/seam/routes/phones.py
@@ -9,6 +9,8 @@ from .phones_simulate import (
     AbstractAsyncPhonesSimulate,
     AsyncPhonesSimulate,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractPhones(abc.ABC):
@@ -153,7 +155,7 @@ class Phones(AbstractPhones):
 
         res = self.client.get("/phones/get", params=params)
 
-        return Phone.from_dict(res["phone"])
+        return Phone.from_dict(unwrap(res, "phone", "/phones/get"))
 
     @route_metadata(
         path="/phones/list", has_required_parameters=False, has_pagination=False
@@ -180,7 +182,9 @@ class Phones(AbstractPhones):
 
         res = self.client.get("/phones/list", params=params)
 
-        return [Phone.from_dict(item) for item in res["phones"]]
+        return [
+            Phone.from_dict(item) for item in unwrap_list(res, "phones", "/phones/list")
+        ]
 
 
 class AsyncPhones(AbstractAsyncPhones):
@@ -237,7 +241,7 @@ class AsyncPhones(AbstractAsyncPhones):
 
         res = await self.client.get("/phones/get", params=params)
 
-        return Phone.from_dict(res["phone"])
+        return Phone.from_dict(unwrap(res, "phone", "/phones/get"))
 
     @route_metadata(
         path="/phones/list", has_required_parameters=False, has_pagination=False
@@ -264,4 +268,6 @@ class AsyncPhones(AbstractAsyncPhones):
 
         res = await self.client.get("/phones/list", params=params)
 
-        return [Phone.from_dict(item) for item in res["phones"]]
+        return [
+            Phone.from_dict(item) for item in unwrap_list(res, "phones", "/phones/list")
+        ]

--- a/seam/routes/phones_simulate.py
+++ b/seam/routes/phones_simulate.py
@@ -3,6 +3,7 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import Phone
+from ..response import unwrap
 
 
 class AbstractPhonesSimulate(abc.ABC):
@@ -110,7 +111,9 @@ class PhonesSimulate(AbstractPhonesSimulate):
             "/phones/simulate/create_sandbox_phone", json=json_payload
         )
 
-        return Phone.from_dict(res["phone"])
+        return Phone.from_dict(
+            unwrap(res, "phone", "/phones/simulate/create_sandbox_phone")
+        )
 
 
 class AsyncPhonesSimulate(AbstractAsyncPhonesSimulate):
@@ -164,4 +167,6 @@ class AsyncPhonesSimulate(AbstractAsyncPhonesSimulate):
             "/phones/simulate/create_sandbox_phone", json=json_payload
         )
 
-        return Phone.from_dict(res["phone"])
+        return Phone.from_dict(
+            unwrap(res, "phone", "/phones/simulate/create_sandbox_phone")
+        )

--- a/seam/routes/spaces.py
+++ b/seam/routes/spaces.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import Space, Batch
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractSpaces(abc.ABC):
@@ -617,7 +619,7 @@ class Spaces(AbstractSpaces):
 
         res = self.client.post("/spaces/create", json=json_payload)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/create"))
 
     @route_metadata(
         path="/spaces/delete", has_required_parameters=True, has_pagination=False
@@ -667,7 +669,7 @@ class Spaces(AbstractSpaces):
 
         res = self.client.get("/spaces/get", params=params)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/get"))
 
     @route_metadata(
         path="/spaces/get_related", has_required_parameters=True, has_pagination=False
@@ -733,7 +735,7 @@ class Spaces(AbstractSpaces):
 
         res = self.client.get("/spaces/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/spaces/get_related"))
 
     @route_metadata(
         path="/spaces/list", has_required_parameters=False, has_pagination=True
@@ -775,7 +777,9 @@ class Spaces(AbstractSpaces):
 
         res = self.client.get("/spaces/list", params=params)
 
-        return [Space.from_dict(item) for item in res["spaces"]]
+        return [
+            Space.from_dict(item) for item in unwrap_list(res, "spaces", "/spaces/list")
+        ]
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",
@@ -913,7 +917,7 @@ class Spaces(AbstractSpaces):
 
         res = self.client.patch("/spaces/update", json=json_payload)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/update"))
 
 
 class AsyncSpaces(AbstractAsyncSpaces):
@@ -1065,7 +1069,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.post("/spaces/create", json=json_payload)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/create"))
 
     @route_metadata(
         path="/spaces/delete", has_required_parameters=True, has_pagination=False
@@ -1115,7 +1119,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.get("/spaces/get", params=params)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/get"))
 
     @route_metadata(
         path="/spaces/get_related", has_required_parameters=True, has_pagination=False
@@ -1181,7 +1185,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.get("/spaces/get_related", params=params)
 
-        return Batch.from_dict(res["batch"])
+        return Batch.from_dict(unwrap(res, "batch", "/spaces/get_related"))
 
     @route_metadata(
         path="/spaces/list", has_required_parameters=False, has_pagination=True
@@ -1223,7 +1227,9 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.get("/spaces/list", params=params)
 
-        return [Space.from_dict(item) for item in res["spaces"]]
+        return [
+            Space.from_dict(item) for item in unwrap_list(res, "spaces", "/spaces/list")
+        ]
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",
@@ -1361,4 +1367,4 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.patch("/spaces/update", json=json_payload)
 
-        return Space.from_dict(res["space"])
+        return Space.from_dict(unwrap(res, "space", "/spaces/update"))

--- a/seam/routes/thermostats.py
+++ b/seam/routes/thermostats.py
@@ -26,6 +26,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractThermostats(abc.ABC):
@@ -963,7 +965,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/activate_climate_preset")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1013,7 +1017,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/cool")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1180,7 +1186,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/heat")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1244,7 +1252,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/heat_cool")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1317,7 +1327,10 @@ class Thermostats(AbstractThermostats):
 
         res = self.client.get("/thermostats/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/thermostats/list")
+        ]
 
     @route_metadata(
         path="/thermostats/off", has_required_parameters=True, has_pagination=False
@@ -1355,7 +1368,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/off")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1440,7 +1455,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/set_fan_mode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1509,7 +1526,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/set_hvac_mode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1725,7 +1744,9 @@ class Thermostats(AbstractThermostats):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/update_weekly_program")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1799,7 +1820,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/activate_climate_preset")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -1849,7 +1872,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/cool")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2018,7 +2043,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/heat")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2082,7 +2109,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/heat_cool")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2155,7 +2184,10 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         res = await self.client.get("/thermostats/list", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(res, "devices", "/thermostats/list")
+        ]
 
     @route_metadata(
         path="/thermostats/off", has_required_parameters=True, has_pagination=False
@@ -2193,7 +2225,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/off")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2280,7 +2314,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/set_fan_mode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2349,7 +2385,9 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/set_hvac_mode")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -2569,6 +2607,8 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/update_weekly_program")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/thermostats_daily_programs.py
+++ b/seam/routes/thermostats_daily_programs.py
@@ -7,6 +7,7 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
 
 
 class AbstractThermostatsDailyPrograms(abc.ABC):
@@ -155,7 +156,11 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
         res = self.client.post("/thermostats/daily_programs/create", json=json_payload)
 
-        return ThermostatDailyProgram.from_dict(res["thermostat_daily_program"])
+        return ThermostatDailyProgram.from_dict(
+            unwrap(
+                res, "thermostat_daily_program", "/thermostats/daily_programs/create"
+            )
+        )
 
     @route_metadata(
         path="/thermostats/daily_programs/delete",
@@ -232,7 +237,9 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/daily_programs/update")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -279,7 +286,11 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
             "/thermostats/daily_programs/create", json=json_payload
         )
 
-        return ThermostatDailyProgram.from_dict(res["thermostat_daily_program"])
+        return ThermostatDailyProgram.from_dict(
+            unwrap(
+                res, "thermostat_daily_program", "/thermostats/daily_programs/create"
+            )
+        )
 
     @route_metadata(
         path="/thermostats/daily_programs/delete",
@@ -358,6 +369,8 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/thermostats/daily_programs/update")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )

--- a/seam/routes/thermostats_schedules.py
+++ b/seam/routes/thermostats_schedules.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import ThermostatSchedule
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractThermostatsSchedules(abc.ABC):
@@ -274,7 +276,9 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
         res = self.client.post("/thermostats/schedules/create", json=json_payload)
 
-        return ThermostatSchedule.from_dict(res["thermostat_schedule"])
+        return ThermostatSchedule.from_dict(
+            unwrap(res, "thermostat_schedule", "/thermostats/schedules/create")
+        )
 
     @route_metadata(
         path="/thermostats/schedules/delete",
@@ -326,7 +330,9 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
         res = self.client.get("/thermostats/schedules/get", params=params)
 
-        return ThermostatSchedule.from_dict(res["thermostat_schedule"])
+        return ThermostatSchedule.from_dict(
+            unwrap(res, "thermostat_schedule", "/thermostats/schedules/get")
+        )
 
     @route_metadata(
         path="/thermostats/schedules/list",
@@ -360,7 +366,10 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
         res = self.client.get("/thermostats/schedules/list", params=params)
 
         return [
-            ThermostatSchedule.from_dict(item) for item in res["thermostat_schedules"]
+            ThermostatSchedule.from_dict(item)
+            for item in unwrap_list(
+                res, "thermostat_schedules", "/thermostats/schedules/list"
+            )
         ]
 
     @route_metadata(
@@ -487,7 +496,9 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
         res = await self.client.post("/thermostats/schedules/create", json=json_payload)
 
-        return ThermostatSchedule.from_dict(res["thermostat_schedule"])
+        return ThermostatSchedule.from_dict(
+            unwrap(res, "thermostat_schedule", "/thermostats/schedules/create")
+        )
 
     @route_metadata(
         path="/thermostats/schedules/delete",
@@ -539,7 +550,9 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
         res = await self.client.get("/thermostats/schedules/get", params=params)
 
-        return ThermostatSchedule.from_dict(res["thermostat_schedule"])
+        return ThermostatSchedule.from_dict(
+            unwrap(res, "thermostat_schedule", "/thermostats/schedules/get")
+        )
 
     @route_metadata(
         path="/thermostats/schedules/list",
@@ -573,7 +586,10 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
         res = await self.client.get("/thermostats/schedules/list", params=params)
 
         return [
-            ThermostatSchedule.from_dict(item) for item in res["thermostat_schedules"]
+            ThermostatSchedule.from_dict(item)
+            for item in unwrap_list(
+                res, "thermostat_schedules", "/thermostats/schedules/list"
+            )
         ]
 
     @route_metadata(

--- a/seam/routes/user_identities.py
+++ b/seam/routes/user_identities.py
@@ -17,6 +17,8 @@ from .user_identities_unmanaged import (
     AbstractAsyncUserIdentitiesUnmanaged,
     AsyncUserIdentitiesUnmanaged,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractUserIdentities(abc.ABC):
@@ -644,7 +646,9 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.post("/user_identities/create", json=json_payload)
 
-        return UserIdentity.from_dict(res["user_identity"])
+        return UserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/create")
+        )
 
     @route_metadata(
         path="/user_identities/delete",
@@ -712,7 +716,9 @@ class UserIdentities(AbstractUserIdentities):
             "/user_identities/generate_instant_key", json=json_payload
         )
 
-        return InstantKey.from_dict(res["instant_key"])
+        return InstantKey.from_dict(
+            unwrap(res, "instant_key", "/user_identities/generate_instant_key")
+        )
 
     @route_metadata(
         path="/user_identities/get", has_required_parameters=True, has_pagination=False
@@ -746,7 +752,9 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/get", params=params)
 
-        return UserIdentity.from_dict(res["user_identity"])
+        return UserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/get")
+        )
 
     @route_metadata(
         path="/user_identities/grant_access_to_device",
@@ -824,7 +832,10 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/list", params=params)
 
-        return [UserIdentity.from_dict(item) for item in res["user_identities"]]
+        return [
+            UserIdentity.from_dict(item)
+            for item in unwrap_list(res, "user_identities", "/user_identities/list")
+        ]
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",
@@ -851,7 +862,12 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/list_accessible_devices", params=params)
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(
+                res, "devices", "/user_identities/list_accessible_devices"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_accessible_entrances",
@@ -880,7 +896,12 @@ class UserIdentities(AbstractUserIdentities):
             "/user_identities/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/user_identities/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_acs_systems",
@@ -907,7 +928,12 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/list_acs_systems", params=params)
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_systems", "/user_identities/list_acs_systems"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_acs_users",
@@ -934,7 +960,10 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/list_acs_users", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/user_identities/list_acs_users")
+        ]
 
     @route_metadata(
         path="/user_identities/merge",
@@ -1189,7 +1218,9 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.post("/user_identities/create", json=json_payload)
 
-        return UserIdentity.from_dict(res["user_identity"])
+        return UserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/create")
+        )
 
     @route_metadata(
         path="/user_identities/delete",
@@ -1257,7 +1288,9 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
             "/user_identities/generate_instant_key", json=json_payload
         )
 
-        return InstantKey.from_dict(res["instant_key"])
+        return InstantKey.from_dict(
+            unwrap(res, "instant_key", "/user_identities/generate_instant_key")
+        )
 
     @route_metadata(
         path="/user_identities/get", has_required_parameters=True, has_pagination=False
@@ -1291,7 +1324,9 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.get("/user_identities/get", params=params)
 
-        return UserIdentity.from_dict(res["user_identity"])
+        return UserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/get")
+        )
 
     @route_metadata(
         path="/user_identities/grant_access_to_device",
@@ -1373,7 +1408,10 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.get("/user_identities/list", params=params)
 
-        return [UserIdentity.from_dict(item) for item in res["user_identities"]]
+        return [
+            UserIdentity.from_dict(item)
+            for item in unwrap_list(res, "user_identities", "/user_identities/list")
+        ]
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",
@@ -1402,7 +1440,12 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
             "/user_identities/list_accessible_devices", params=params
         )
 
-        return [Device.from_dict(item) for item in res["devices"]]
+        return [
+            Device.from_dict(item)
+            for item in unwrap_list(
+                res, "devices", "/user_identities/list_accessible_devices"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_accessible_entrances",
@@ -1433,7 +1476,12 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
             "/user_identities/list_accessible_entrances", params=params
         )
 
-        return [AcsEntrance.from_dict(item) for item in res["acs_entrances"]]
+        return [
+            AcsEntrance.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_entrances", "/user_identities/list_accessible_entrances"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_acs_systems",
@@ -1460,7 +1508,12 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.get("/user_identities/list_acs_systems", params=params)
 
-        return [AcsSystem.from_dict(item) for item in res["acs_systems"]]
+        return [
+            AcsSystem.from_dict(item)
+            for item in unwrap_list(
+                res, "acs_systems", "/user_identities/list_acs_systems"
+            )
+        ]
 
     @route_metadata(
         path="/user_identities/list_acs_users",
@@ -1487,7 +1540,10 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.get("/user_identities/list_acs_users", params=params)
 
-        return [AcsUser.from_dict(item) for item in res["acs_users"]]
+        return [
+            AcsUser.from_dict(item)
+            for item in unwrap_list(res, "acs_users", "/user_identities/list_acs_users")
+        ]
 
     @route_metadata(
         path="/user_identities/merge",

--- a/seam/routes/user_identities_unmanaged.py
+++ b/seam/routes/user_identities_unmanaged.py
@@ -4,6 +4,8 @@ from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..null import Null
 from ..resources import UnmanagedUserIdentity
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractUserIdentitiesUnmanaged(abc.ABC):
@@ -150,7 +152,9 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
         res = self.client.get("/user_identities/unmanaged/get", params=params)
 
-        return UnmanagedUserIdentity.from_dict(res["user_identity"])
+        return UnmanagedUserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/unmanaged/get")
+        )
 
     @route_metadata(
         path="/user_identities/unmanaged/list",
@@ -190,7 +194,10 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
         res = self.client.get("/user_identities/unmanaged/list", params=params)
 
         return [
-            UnmanagedUserIdentity.from_dict(item) for item in res["user_identities"]
+            UnmanagedUserIdentity.from_dict(item)
+            for item in unwrap_list(
+                res, "user_identities", "/user_identities/unmanaged/list"
+            )
         ]
 
     @route_metadata(
@@ -265,7 +272,9 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
         res = await self.client.get("/user_identities/unmanaged/get", params=params)
 
-        return UnmanagedUserIdentity.from_dict(res["user_identity"])
+        return UnmanagedUserIdentity.from_dict(
+            unwrap(res, "user_identity", "/user_identities/unmanaged/get")
+        )
 
     @route_metadata(
         path="/user_identities/unmanaged/list",
@@ -305,7 +314,10 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
         res = await self.client.get("/user_identities/unmanaged/list", params=params)
 
         return [
-            UnmanagedUserIdentity.from_dict(item) for item in res["user_identities"]
+            UnmanagedUserIdentity.from_dict(item)
+            for item in unwrap_list(
+                res, "user_identities", "/user_identities/unmanaged/list"
+            )
         ]
 
     @route_metadata(

--- a/seam/routes/webhooks.py
+++ b/seam/routes/webhooks.py
@@ -3,6 +3,8 @@ import abc
 from ..client import SeamHttpClient, AsyncSeamHttpClient
 from ..route import route_metadata
 from ..resources import Webhook
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractWebhooks(abc.ABC):
@@ -145,7 +147,7 @@ class Webhooks(AbstractWebhooks):
 
         res = self.client.post("/webhooks/create", json=json_payload)
 
-        return Webhook.from_dict(res["webhook"])
+        return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/create"))
 
     @route_metadata(
         path="/webhooks/delete", has_required_parameters=True, has_pagination=False
@@ -189,7 +191,7 @@ class Webhooks(AbstractWebhooks):
 
         res = self.client.get("/webhooks/get", params=params)
 
-        return Webhook.from_dict(res["webhook"])
+        return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/get"))
 
     @route_metadata(
         path="/webhooks/list", has_required_parameters=False, has_pagination=False
@@ -202,7 +204,10 @@ class Webhooks(AbstractWebhooks):
 
         res = self.client.get("/webhooks/list", params=params)
 
-        return [Webhook.from_dict(item) for item in res["webhooks"]]
+        return [
+            Webhook.from_dict(item)
+            for item in unwrap_list(res, "webhooks", "/webhooks/list")
+        ]
 
     @route_metadata(
         path="/webhooks/update", has_required_parameters=True, has_pagination=False
@@ -262,7 +267,7 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
 
         res = await self.client.post("/webhooks/create", json=json_payload)
 
-        return Webhook.from_dict(res["webhook"])
+        return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/create"))
 
     @route_metadata(
         path="/webhooks/delete", has_required_parameters=True, has_pagination=False
@@ -306,7 +311,7 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
 
         res = await self.client.get("/webhooks/get", params=params)
 
-        return Webhook.from_dict(res["webhook"])
+        return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/get"))
 
     @route_metadata(
         path="/webhooks/list", has_required_parameters=False, has_pagination=False
@@ -319,7 +324,10 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
 
         res = await self.client.get("/webhooks/list", params=params)
 
-        return [Webhook.from_dict(item) for item in res["webhooks"]]
+        return [
+            Webhook.from_dict(item)
+            for item in unwrap_list(res, "webhooks", "/webhooks/list")
+        ]
 
     @route_metadata(
         path="/webhooks/update", has_required_parameters=True, has_pagination=False

--- a/seam/routes/workspaces.py
+++ b/seam/routes/workspaces.py
@@ -8,6 +8,8 @@ from ..modules.action_attempts import (
     resolve_action_attempt,
     resolve_action_attempt_async,
 )
+from ..response import unwrap
+from ..response import unwrap_list
 
 
 class AbstractWorkspaces(abc.ABC):
@@ -285,7 +287,7 @@ class Workspaces(AbstractWorkspaces):
 
         res = self.client.post("/workspaces/create", json=json_payload)
 
-        return Workspace.from_dict(res["workspace"])
+        return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/create"))
 
     @route_metadata(
         path="/workspaces/get", has_required_parameters=False, has_pagination=False
@@ -298,7 +300,7 @@ class Workspaces(AbstractWorkspaces):
 
         res = self.client.get("/workspaces/get", params=params)
 
-        return Workspace.from_dict(res["workspace"])
+        return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/get"))
 
     @route_metadata(
         path="/workspaces/list", has_required_parameters=False, has_pagination=False
@@ -311,7 +313,10 @@ class Workspaces(AbstractWorkspaces):
 
         res = self.client.get("/workspaces/list", params=params)
 
-        return [Workspace.from_dict(item) for item in res["workspaces"]]
+        return [
+            Workspace.from_dict(item)
+            for item in unwrap_list(res, "workspaces", "/workspaces/list")
+        ]
 
     @route_metadata(
         path="/workspaces/reset_sandbox",
@@ -338,7 +343,9 @@ class Workspaces(AbstractWorkspaces):
 
         return resolve_action_attempt(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/workspaces/reset_sandbox")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 
@@ -474,7 +481,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
         res = await self.client.post("/workspaces/create", json=json_payload)
 
-        return Workspace.from_dict(res["workspace"])
+        return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/create"))
 
     @route_metadata(
         path="/workspaces/get", has_required_parameters=False, has_pagination=False
@@ -487,7 +494,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
         res = await self.client.get("/workspaces/get", params=params)
 
-        return Workspace.from_dict(res["workspace"])
+        return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/get"))
 
     @route_metadata(
         path="/workspaces/list", has_required_parameters=False, has_pagination=False
@@ -500,7 +507,10 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
         res = await self.client.get("/workspaces/list", params=params)
 
-        return [Workspace.from_dict(item) for item in res["workspaces"]]
+        return [
+            Workspace.from_dict(item)
+            for item in unwrap_list(res, "workspaces", "/workspaces/list")
+        ]
 
     @route_metadata(
         path="/workspaces/reset_sandbox",
@@ -527,7 +537,9 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
         return await resolve_action_attempt_async(
             client=self.client,
-            action_attempt=action_attempt_from_dict(res["action_attempt"]),
+            action_attempt=action_attempt_from_dict(
+                unwrap(res, "action_attempt", "/workspaces/reset_sandbox")
+            ),
             wait_for_action_attempt=wait_for_action_attempt,
         )
 

--- a/test/invalid_response_test.py
+++ b/test/invalid_response_test.py
@@ -1,0 +1,155 @@
+import pytest
+
+from seam import AsyncSeam, Seam, SeamError, SeamHttpInvalidResponseError
+
+DEVICE_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def make_seam(endpoint):
+    return Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+
+def test_a_response_missing_the_expected_key_raises(recording_server):
+    with recording_server([(200, {"wrong_key": {}})]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match="Seam returned an invalid response for /devices/get: "
+            'expected "device", which the response does not contain',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_null_response_body_raises(recording_server):
+    with recording_server([(200, None)]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "device", got NoneType instead of a response object',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_string_response_body_raises(recording_server):
+    with recording_server([(200, '"a json string"', "application/json")]) as (
+        endpoint,
+        _,
+    ):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "device", got str instead of a response object',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_non_json_gateway_page_raises(recording_server):
+    with recording_server(
+        [(200, "<html>Scheduled maintenance</html>", "application/json")]
+    ) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "device", got str instead of a response object',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_plain_text_response_raises(recording_server):
+    with recording_server([(200, "ok")]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "device", got str instead of a response object',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_non_object_value_under_the_response_key_raises(recording_server):
+    with recording_server([(200, {"device": "not-an-object"})]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "device", got str instead of an object',
+        ):
+            seam.devices.get(device_id=DEVICE_ID)
+
+
+def test_a_non_list_value_under_a_list_response_key_raises(recording_server):
+    with recording_server([(200, {"devices": {"not": "a list"}})]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match="Seam returned an invalid response for /devices/list: "
+            'expected "devices", got dict instead of a list',
+        ):
+            seam.devices.list()
+
+
+def test_a_malformed_poll_response_raises_mid_wait(recording_server):
+    pending_response = {
+        "action_attempt": {
+            "action_attempt_id": "11111111-1111-1111-1111-111111111111",
+            "action_type": "UNLOCK_DOOR",
+            "status": "pending",
+            "result": None,
+            "error": None,
+        }
+    }
+
+    with recording_server([(200, pending_response), (200, {"nonsense": True})]) as (
+        endpoint,
+        _,
+    ):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match="Seam returned an invalid response for /action_attempts/get: "
+            'expected "action_attempt", which the response does not contain',
+        ):
+            seam.action_attempts.get(
+                action_attempt_id="11111111-1111-1111-1111-111111111111",
+                wait_for_action_attempt={"timeout": 5, "polling_interval": 0.05},
+            )
+
+
+def test_the_invalid_response_error_is_a_seam_error(recording_server):
+    with recording_server([(200, {"wrong_key": {}})]) as (endpoint, _):
+        seam = make_seam(endpoint)
+
+        with pytest.raises(SeamError) as exc_info:
+            seam.devices.get(device_id=DEVICE_ID)
+
+    assert isinstance(exc_info.value, SeamHttpInvalidResponseError)
+    assert exc_info.value.path == "/devices/get"
+    assert exc_info.value.response_key == "device"
+
+
+async def test_a_response_missing_the_expected_key_raises_async(recording_server):
+    with recording_server([(200, {"wrong_key": {}})]) as (endpoint, _):
+        async with AsyncSeam(api_key="seam_apikey_token", endpoint=endpoint) as seam:
+            with pytest.raises(
+                SeamHttpInvalidResponseError,
+                match='expected "device", which the response does not contain',
+            ):
+                await seam.devices.get(device_id=DEVICE_ID)
+
+
+async def test_a_non_list_value_under_a_list_response_key_raises_async(
+    recording_server,
+):
+    with recording_server([(200, {"devices": None})]) as (endpoint, _):
+        async with AsyncSeam(api_key="seam_apikey_token", endpoint=endpoint) as seam:
+            with pytest.raises(
+                SeamHttpInvalidResponseError,
+                match='expected "devices", got NoneType instead of a list',
+            ):
+                await seam.devices.list()


### PR DESCRIPTION
## What

A 2xx response with an unexpected envelope — a proxy rewrite, a maintenance page served with a JSON content type, a renamed response key — escaped the SDK's error hierarchy entirely: generated routes unwrapped `res["device"]` inline at ~240 sites, so callers got a bare `KeyError`, `TypeError: string indices must be integers`, or a raw `json.decoder.JSONDecodeError` (SDK audit finding M3; same fix as JS #1005 and PHP #475).

- New `SeamHttpInvalidResponseError(SeamError)` with `path` and `response_key` attributes and the same message shape as the JS/PHP SDKs: `Seam returned an invalid response for {path}: expected "{key}", {reason}`.
- New hand-written `seam/response.py` with `unwrap` / `unwrap_list` helpers that verify the body is an object, the key is present, and the value has the right shape.
- The route codegen template routes all three return forms (object, list, action-attempt) through the helpers — a template change, so it lands at every generated site at once. The two hand-written poll sites in `seam/modules/action_attempts.py` use the same helper.
- `_handle_response` now hands an unparseable JSON body on as text instead of leaking `JSONDecodeError`, so it surfaces as the same invalid-response error (this matches the JS SDK, where axios keeps the string).

**Depends on [#634](https://github.com/seamapi/python/pull/634)** (SeamError base) and is stacked on [#637](https://github.com/seamapi/python/pull/637); the diff shrinks as those merge.

## Testing

New `test/invalid_response_test.py` (sync + async, recording server, pinned messages): missing key, JSON `null`/string body, HTML page with a JSON content type, plain-text response, non-object value under the key, non-list value under a list key, and a malformed poll response mid-wait.

Revert check: with `seam/routes/devices.py` and `seam/client.py` reverted, the tests fail with the audit's exact symptoms (`KeyError: 'device'`, `TypeError: string indices must be integers`, raw `JSONDecodeError`).

Regeneration is drift-free at this head; the generated diff touches exactly the unwrap sites. Full suite: 216 passed; mypy, pylint (10.00), black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_