### PR TITLE
fix: Leave pagination params out of the at least one parameter guard

### DIFF
--- a/codegen/layouts/partials/method-docstring.hbs
+++ b/codegen/layouts/partials/method-docstring.hbs
@@ -4,7 +4,7 @@
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.{{/if}}{{#unless (eq returnType "None")}}
 
-        :returns: {{{indent (pythonDoc responseDescription) 8}}}{{/unless}}{{#if hasRequiredParameters}}
+        :returns: {{{indent (pythonDoc responseDescription) 8}}}{{/unless}}{{#if requiresAtLeastOneParameter}}
 
         :raises ValueError: At least one parameter must be provided.{{/if}}{{#if isDeprecated}}
 

--- a/codegen/layouts/partials/route-method.hbs
+++ b/codegen/layouts/partials/route-method.hbs
@@ -1,4 +1,4 @@
-    @route_metadata(path="{{path}}", has_required_parameters={{#if hasRequiredParameters}}True{{else}}False{{/if}}, has_pagination={{#if hasPagination}}True{{else}}False{{/if}})
+    @route_metadata(path="{{path}}", at_least_one_parameter_names=({{#each atLeastOneParameterNames}}"{{this}}",{{#unless @last}} {{/unless}}{{/each}}), has_pagination={{#if hasPagination}}True{{else}}False{{/if}})
     {{#if isAsync}}async {{/if}}def {{> method-signature}}:
         """{{> method-docstring}}"""
         {{payloadVar}}: Dict[str, Any] = {}
@@ -7,9 +7,12 @@
         if {{name}} is not None:
             {{../payloadVar}}["{{name}}"] = {{name}}
 {{/each}}
-{{#if hasRequiredParameters}}
+{{#if requiresAtLeastOneParameter}}
 
-        if not {{payloadVar}}:
+        if all(
+            param is None
+            for param in ({{#each atLeastOneParameterNames}}{{this}},{{#unless @last}} {{/unless}}{{/each}})
+        ):
             raise ValueError("At least one parameter is required for {{path}}")
 {{/if}}
 

--- a/codegen/lib/layouts/route.ts
+++ b/codegen/lib/layouts/route.ts
@@ -14,7 +14,8 @@ export interface MethodLayoutContext {
   httpVerb: string
   payloadVar: string
   payloadArg: string
-  hasRequiredParameters: boolean
+  requiresAtLeastOneParameter: boolean
+  atLeastOneParameterNames: string[]
   hasPagination: boolean
   description: string
   responseDescription: string
@@ -66,6 +67,16 @@ export interface RouteLayoutContext {
   methods: MethodLayoutContext[]
 }
 
+const paginationParameterNames = new Set(['limit', 'page_cursor'])
+
+const getAtLeastOneParameterNames = (method: ClassMethod): string[] =>
+  method.hasRequiredParameters &&
+  method.parameters.every(({ required }) => !(required ?? false))
+    ? method.parameters
+        .map(({ name }) => name)
+        .filter((name) => !paginationParameterNames.has(name))
+    : []
+
 const getRequestLayoutContext = (
   preferredMethod: string,
 ): Pick<MethodLayoutContext, 'httpVerb' | 'payloadVar' | 'payloadArg'> => {
@@ -84,7 +95,8 @@ export const getMethodLayoutContext = (
   name: method.methodName,
   path: method.path,
   ...getRequestLayoutContext(method.preferredMethod),
-  hasRequiredParameters: method.hasRequiredParameters,
+  requiresAtLeastOneParameter: getAtLeastOneParameterNames(method).length > 0,
+  atLeastOneParameterNames: getAtLeastOneParameterNames(method),
   hasPagination: method.hasPagination,
   description: method.description,
   responseDescription: method.responseDescription,

--- a/seam/route.py
+++ b/seam/route.py
@@ -1,17 +1,22 @@
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, Tuple, TypeVar, cast
 
 F = TypeVar("F", bound=Callable)
 
 
-def route_metadata(*, path: str, has_required_parameters: bool, has_pagination: bool):
+def route_metadata(
+    *,
+    path: str,
+    has_pagination: bool,
+    at_least_one_parameter_names: Tuple[str, ...] = (),
+):
     """Attach generated route metadata to a request callable."""
 
     def decorate(request: F) -> F:
         # Functions do not declare these attributes, so set them through Any.
         route = cast(Any, request)
         route.__seam_path__ = path
-        route.__seam_has_required_parameters__ = has_required_parameters
         route.__seam_has_pagination__ = has_pagination
+        route.__seam_at_least_one_parameter_names__ = at_least_one_parameter_names
         return request
 
     return decorate

--- a/seam/routes/access_codes.py
+++ b/seam/routes/access_codes.py
@@ -93,9 +93,7 @@ class AbstractAccessCodes(abc.ABC):
 
         :param use_offline_access_code: Deprecated: Use ``is_offline_access_code`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -159,9 +157,7 @@ class AbstractAccessCodes(abc.ABC):
 
         :param use_backup_access_code_pool: Indicates whether to use a `backup access code pool <https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes>`_ provided by Seam. If ``true``, you can use ```/access_codes/pull_backup_access_code`` <https://docs.seam.co/api/access_codes/pull_backup_access_code>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -171,8 +167,7 @@ class AbstractAccessCodes(abc.ABC):
         :param access_code_id: ID of the access code that you want to delete.
 
         :param device_id: ID of the device for which you want to delete the access code.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -181,9 +176,7 @@ class AbstractAccessCodes(abc.ABC):
 
         :param device_id: ID of the device for which you want to generate a code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -267,9 +260,7 @@ class AbstractAccessCodes(abc.ABC):
 
         :param access_code_id: ID of the access code for which you want to pull a backup access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -292,8 +283,7 @@ class AbstractAccessCodes(abc.ABC):
         :param min_code_length: Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either ``min_code_length``/``max_code_length`` or ``supported_code_lengths``.
 
         :param supported_code_lengths: Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either ``supported_code_lengths`` or ``min_code_length``/``max_code_length``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -343,8 +333,7 @@ class AbstractAccessCodes(abc.ABC):
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
 
         :param type: Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set ``type`` to ``ongoing``. See also `Changing a time-bound access code to permanent access <https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -375,8 +364,7 @@ class AbstractAccessCodes(abc.ABC):
         To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called ``appearance``. This is an object with a ``name`` property and, optionally, ``first_name`` and ``last_name`` properties (for providers that break down a name into components).
 
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -453,9 +441,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
 
         :param use_offline_access_code: Deprecated: Use ``is_offline_access_code`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -519,9 +505,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
 
         :param use_backup_access_code_pool: Indicates whether to use a `backup access code pool <https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes>`_ provided by Seam. If ``true``, you can use ```/access_codes/pull_backup_access_code`` <https://docs.seam.co/api/access_codes/pull_backup_access_code>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -533,8 +517,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
         :param access_code_id: ID of the access code that you want to delete.
 
         :param device_id: ID of the device for which you want to delete the access code.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -543,9 +526,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
 
         :param device_id: ID of the device for which you want to generate a code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -629,9 +610,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
 
         :param access_code_id: ID of the access code for which you want to pull a backup access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -654,8 +633,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
         :param min_code_length: Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either ``min_code_length``/``max_code_length`` or ``supported_code_lengths``.
 
         :param supported_code_lengths: Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either ``supported_code_lengths`` or ``min_code_length``/``max_code_length``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -705,8 +683,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
 
         :param type: Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set ``type`` to ``ongoing``. See also `Changing a time-bound access code to permanent access <https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -737,8 +714,7 @@ class AbstractAsyncAccessCodes(abc.ABC):
         To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called ``appearance``. This is an object with a ``name`` property and, optionally, ``first_name`` and ``last_name`` properties (for providers that break down a name into components).
 
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -758,7 +734,9 @@ class AccessCodes(AbstractAccessCodes):
         return self._unmanaged
 
     @route_metadata(
-        path="/access_codes/create", has_required_parameters=True, has_pagination=False
+        path="/access_codes/create",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def create(
         self,
@@ -820,9 +798,7 @@ class AccessCodes(AbstractAccessCodes):
 
         :param use_offline_access_code: Deprecated: Use ``is_offline_access_code`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -860,18 +836,13 @@ class AccessCodes(AbstractAccessCodes):
         if use_offline_access_code is not None:
             json_payload["use_offline_access_code"] = use_offline_access_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/create"
-            )
-
         res = self.client.post("/access_codes/create", json=json_payload)
 
         return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/create"))
 
     @route_metadata(
         path="/access_codes/create_multiple",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create_multiple(
@@ -934,9 +905,7 @@ class AccessCodes(AbstractAccessCodes):
 
         :param use_backup_access_code_pool: Indicates whether to use a `backup access code pool <https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes>`_ provided by Seam. If ``true``, you can use ```/access_codes/pull_backup_access_code`` <https://docs.seam.co/api/access_codes/pull_backup_access_code>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -968,11 +937,6 @@ class AccessCodes(AbstractAccessCodes):
         if use_backup_access_code_pool is not None:
             json_payload["use_backup_access_code_pool"] = use_backup_access_code_pool
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/create_multiple"
-            )
-
         res = self.client.put("/access_codes/create_multiple", json=json_payload)
 
         return [
@@ -983,7 +947,9 @@ class AccessCodes(AbstractAccessCodes):
         ]
 
     @route_metadata(
-        path="/access_codes/delete", has_required_parameters=True, has_pagination=False
+        path="/access_codes/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def delete(self, *, access_code_id: str, device_id: Optional[str] = None) -> None:
         """Deletes an `access code <https://docs.seam.co/low-level-apis/smart-locks/access-codes>`_.
@@ -991,8 +957,7 @@ class AccessCodes(AbstractAccessCodes):
         :param access_code_id: ID of the access code that you want to delete.
 
         :param device_id: ID of the device for which you want to delete the access code.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -1000,18 +965,13 @@ class AccessCodes(AbstractAccessCodes):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/delete"
-            )
-
         self.client.delete("/access_codes/delete", params=params)
 
         return None
 
     @route_metadata(
         path="/access_codes/generate_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def generate_code(self, *, device_id: str) -> AccessCode:
@@ -1019,18 +979,11 @@ class AccessCodes(AbstractAccessCodes):
 
         :param device_id: ID of the device for which you want to generate a code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/generate_code"
-            )
 
         res = self.client.get("/access_codes/generate_code", params=params)
 
@@ -1039,7 +992,13 @@ class AccessCodes(AbstractAccessCodes):
         )
 
     @route_metadata(
-        path="/access_codes/get", has_required_parameters=True, has_pagination=False
+        path="/access_codes/get",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "code",
+            "device_id",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -1070,7 +1029,14 @@ class AccessCodes(AbstractAccessCodes):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                code,
+                device_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /access_codes/get")
 
         res = self.client.get("/access_codes/get", params=params)
@@ -1078,7 +1044,18 @@ class AccessCodes(AbstractAccessCodes):
         return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/get"))
 
     @route_metadata(
-        path="/access_codes/list", has_required_parameters=True, has_pagination=True
+        path="/access_codes/list",
+        at_least_one_parameter_names=(
+            "access_code_ids",
+            "access_grant_id",
+            "access_grant_key",
+            "access_method_id",
+            "customer_key",
+            "device_id",
+            "search",
+            "user_identifier_key",
+        ),
+        has_pagination=True,
     )
     def list(
         self,
@@ -1144,7 +1121,19 @@ class AccessCodes(AbstractAccessCodes):
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_ids,
+                access_grant_id,
+                access_grant_key,
+                access_method_id,
+                customer_key,
+                device_id,
+                search,
+                user_identifier_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_codes/list"
             )
@@ -1158,7 +1147,7 @@ class AccessCodes(AbstractAccessCodes):
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def pull_backup_access_code(self, *, access_code_id: str) -> AccessCode:
@@ -1174,18 +1163,11 @@ class AccessCodes(AbstractAccessCodes):
 
         :param access_code_id: ID of the access code for which you want to pull a backup access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
             json_payload["access_code_id"] = access_code_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/pull_backup_access_code"
-            )
 
         res = self.client.post(
             "/access_codes/pull_backup_access_code", json=json_payload
@@ -1197,7 +1179,7 @@ class AccessCodes(AbstractAccessCodes):
 
     @route_metadata(
         path="/access_codes/report_device_constraints",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def report_device_constraints(
@@ -1219,8 +1201,7 @@ class AccessCodes(AbstractAccessCodes):
         :param min_code_length: Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either ``min_code_length``/``max_code_length`` or ``supported_code_lengths``.
 
         :param supported_code_lengths: Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either ``supported_code_lengths`` or ``min_code_length``/``max_code_length``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1232,17 +1213,14 @@ class AccessCodes(AbstractAccessCodes):
         if supported_code_lengths is not None:
             json_payload["supported_code_lengths"] = supported_code_lengths
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/report_device_constraints"
-            )
-
         self.client.post("/access_codes/report_device_constraints", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/access_codes/update", has_required_parameters=True, has_pagination=False
+        path="/access_codes/update",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def update(
         self,
@@ -1290,8 +1268,7 @@ class AccessCodes(AbstractAccessCodes):
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
 
         :param type: Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set ``type`` to ``ongoing``. See also `Changing a time-bound access code to permanent access <https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -1319,18 +1296,13 @@ class AccessCodes(AbstractAccessCodes):
         if type is not None:
             json_payload["type"] = type
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/update"
-            )
-
         self.client.patch("/access_codes/update", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/access_codes/update_multiple",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update_multiple(
@@ -1360,8 +1332,7 @@ class AccessCodes(AbstractAccessCodes):
         To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called ``appearance``. This is an object with a ``name`` property and, optionally, ``first_name`` and ``last_name`` properties (for providers that break down a name into components).
 
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if common_code_key is not None:
@@ -1372,11 +1343,6 @@ class AccessCodes(AbstractAccessCodes):
             json_payload["name"] = name
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/update_multiple"
-            )
 
         self.client.patch("/access_codes/update_multiple", json=json_payload)
 
@@ -1399,7 +1365,9 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         return self._unmanaged
 
     @route_metadata(
-        path="/access_codes/create", has_required_parameters=True, has_pagination=False
+        path="/access_codes/create",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def create(
         self,
@@ -1461,9 +1429,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         :param use_offline_access_code: Deprecated: Use ``is_offline_access_code`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1501,18 +1467,13 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if use_offline_access_code is not None:
             json_payload["use_offline_access_code"] = use_offline_access_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/create"
-            )
-
         res = await self.client.post("/access_codes/create", json=json_payload)
 
         return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/create"))
 
     @route_metadata(
         path="/access_codes/create_multiple",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create_multiple(
@@ -1575,9 +1536,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         :param use_backup_access_code_pool: Indicates whether to use a `backup access code pool <https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes>`_ provided by Seam. If ``true``, you can use ```/access_codes/pull_backup_access_code`` <https://docs.seam.co/api/access_codes/pull_backup_access_code>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -1609,11 +1568,6 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if use_backup_access_code_pool is not None:
             json_payload["use_backup_access_code_pool"] = use_backup_access_code_pool
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/create_multiple"
-            )
-
         res = await self.client.put("/access_codes/create_multiple", json=json_payload)
 
         return [
@@ -1624,7 +1578,9 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         ]
 
     @route_metadata(
-        path="/access_codes/delete", has_required_parameters=True, has_pagination=False
+        path="/access_codes/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def delete(
         self, *, access_code_id: str, device_id: Optional[str] = None
@@ -1634,8 +1590,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         :param access_code_id: ID of the access code that you want to delete.
 
         :param device_id: ID of the device for which you want to delete the access code.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -1643,18 +1598,13 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/delete"
-            )
-
         await self.client.delete("/access_codes/delete", params=params)
 
         return None
 
     @route_metadata(
         path="/access_codes/generate_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def generate_code(self, *, device_id: str) -> AccessCode:
@@ -1662,18 +1612,11 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         :param device_id: ID of the device for which you want to generate a code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/generate_code"
-            )
 
         res = await self.client.get("/access_codes/generate_code", params=params)
 
@@ -1682,7 +1625,13 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         )
 
     @route_metadata(
-        path="/access_codes/get", has_required_parameters=True, has_pagination=False
+        path="/access_codes/get",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "code",
+            "device_id",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -1713,7 +1662,14 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                code,
+                device_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /access_codes/get")
 
         res = await self.client.get("/access_codes/get", params=params)
@@ -1721,7 +1677,18 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         return AccessCode.from_dict(unwrap(res, "access_code", "/access_codes/get"))
 
     @route_metadata(
-        path="/access_codes/list", has_required_parameters=True, has_pagination=True
+        path="/access_codes/list",
+        at_least_one_parameter_names=(
+            "access_code_ids",
+            "access_grant_id",
+            "access_grant_key",
+            "access_method_id",
+            "customer_key",
+            "device_id",
+            "search",
+            "user_identifier_key",
+        ),
+        has_pagination=True,
     )
     async def list(
         self,
@@ -1787,7 +1754,19 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_ids,
+                access_grant_id,
+                access_grant_key,
+                access_method_id,
+                customer_key,
+                device_id,
+                search,
+                user_identifier_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_codes/list"
             )
@@ -1801,7 +1780,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def pull_backup_access_code(self, *, access_code_id: str) -> AccessCode:
@@ -1817,18 +1796,11 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         :param access_code_id: ID of the access code for which you want to pull a backup access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
             json_payload["access_code_id"] = access_code_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/pull_backup_access_code"
-            )
 
         res = await self.client.post(
             "/access_codes/pull_backup_access_code", json=json_payload
@@ -1840,7 +1812,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
     @route_metadata(
         path="/access_codes/report_device_constraints",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def report_device_constraints(
@@ -1862,8 +1834,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         :param min_code_length: Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either ``min_code_length``/``max_code_length`` or ``supported_code_lengths``.
 
         :param supported_code_lengths: Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either ``supported_code_lengths`` or ``min_code_length``/``max_code_length``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1875,11 +1846,6 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if supported_code_lengths is not None:
             json_payload["supported_code_lengths"] = supported_code_lengths
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/report_device_constraints"
-            )
-
         await self.client.post(
             "/access_codes/report_device_constraints", json=json_payload
         )
@@ -1887,7 +1853,9 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         return None
 
     @route_metadata(
-        path="/access_codes/update", has_required_parameters=True, has_pagination=False
+        path="/access_codes/update",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def update(
         self,
@@ -1935,8 +1903,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
 
         :param type: Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set ``type`` to ``ongoing``. See also `Changing a time-bound access code to permanent access <https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -1964,18 +1931,13 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         if type is not None:
             json_payload["type"] = type
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/update"
-            )
-
         await self.client.patch("/access_codes/update", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/access_codes/update_multiple",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update_multiple(
@@ -2005,8 +1967,7 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
         To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider's app or on the device as a separate property called ``appearance``. This is an object with a ``name`` property and, optionally, ``first_name`` and ``last_name`` properties (for providers that break down a name into components).
 
         :param starts_at: Date and time at which the validity of the new access code starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if common_code_key is not None:
@@ -2017,11 +1978,6 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
             json_payload["name"] = name
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/update_multiple"
-            )
 
         await self.client.patch("/access_codes/update_multiple", json=json_payload)
 

--- a/seam/routes/access_codes_simulate.py
+++ b/seam/routes/access_codes_simulate.py
@@ -20,9 +20,7 @@ class AbstractAccessCodesSimulate(abc.ABC):
 
         :param name: Name of the simulated unmanaged access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -40,9 +38,7 @@ class AbstractAsyncAccessCodesSimulate(abc.ABC):
 
         :param name: Name of the simulated unmanaged access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -53,7 +49,7 @@ class AccessCodesSimulate(AbstractAccessCodesSimulate):
 
     @route_metadata(
         path="/access_codes/simulate/create_unmanaged_access_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create_unmanaged_access_code(
@@ -67,9 +63,7 @@ class AccessCodesSimulate(AbstractAccessCodesSimulate):
 
         :param name: Name of the simulated unmanaged access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if code is not None:
@@ -78,11 +72,6 @@ class AccessCodesSimulate(AbstractAccessCodesSimulate):
             json_payload["device_id"] = device_id
         if name is not None:
             json_payload["name"] = name
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/simulate/create_unmanaged_access_code"
-            )
 
         res = self.client.post(
             "/access_codes/simulate/create_unmanaged_access_code", json=json_payload
@@ -104,7 +93,7 @@ class AsyncAccessCodesSimulate(AbstractAsyncAccessCodesSimulate):
 
     @route_metadata(
         path="/access_codes/simulate/create_unmanaged_access_code",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create_unmanaged_access_code(
@@ -118,9 +107,7 @@ class AsyncAccessCodesSimulate(AbstractAsyncAccessCodesSimulate):
 
         :param name: Name of the simulated unmanaged access code.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if code is not None:
@@ -129,11 +116,6 @@ class AsyncAccessCodesSimulate(AbstractAsyncAccessCodesSimulate):
             json_payload["device_id"] = device_id
         if name is not None:
             json_payload["name"] = name
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/simulate/create_unmanaged_access_code"
-            )
 
         res = await self.client.post(
             "/access_codes/simulate/create_unmanaged_access_code", json=json_payload

--- a/seam/routes/access_codes_unmanaged.py
+++ b/seam/routes/access_codes_unmanaged.py
@@ -32,8 +32,7 @@ class AbstractAccessCodesUnmanaged(abc.ABC):
         :param force: Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set ``force`` to ``true``.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the access code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -41,8 +40,7 @@ class AbstractAccessCodesUnmanaged(abc.ABC):
         """Deletes an `unmanaged access code <https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes>`_.
 
         :param access_code_id: ID of the unmanaged access code that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -90,9 +88,7 @@ class AbstractAccessCodesUnmanaged(abc.ABC):
 
         :param user_identifier_key: Your user ID for the user by which to filter unmanaged access codes.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -116,8 +112,7 @@ class AbstractAccessCodesUnmanaged(abc.ABC):
         :param force: Indicates whether to force the unmanaged access code update.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -145,8 +140,7 @@ class AbstractAsyncAccessCodesUnmanaged(abc.ABC):
         :param force: Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set ``force`` to ``true``.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the access code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -154,8 +148,7 @@ class AbstractAsyncAccessCodesUnmanaged(abc.ABC):
         """Deletes an `unmanaged access code <https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes>`_.
 
         :param access_code_id: ID of the unmanaged access code that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -203,9 +196,7 @@ class AbstractAsyncAccessCodesUnmanaged(abc.ABC):
 
         :param user_identifier_key: Your user ID for the user by which to filter unmanaged access codes.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -229,8 +220,7 @@ class AbstractAsyncAccessCodesUnmanaged(abc.ABC):
         :param force: Indicates whether to force the unmanaged access code update.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -241,7 +231,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/convert_to_managed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def convert_to_managed(
@@ -265,8 +255,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
         :param force: Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set ``force`` to ``true``.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the access code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -280,11 +269,6 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
                 is_external_modification_allowed
             )
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/convert_to_managed"
-            )
-
         self.client.patch(
             "/access_codes/unmanaged/convert_to_managed", json=json_payload
         )
@@ -293,24 +277,18 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, access_code_id: str) -> None:
         """Deletes an `unmanaged access code <https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes>`_.
 
         :param access_code_id: ID of the unmanaged access code that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if access_code_id is not None:
             params["access_code_id"] = access_code_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/delete"
-            )
 
         self.client.delete("/access_codes/unmanaged/delete", params=params)
 
@@ -318,7 +296,11 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "code",
+            "device_id",
+        ),
         has_pagination=False,
     )
     def get(
@@ -350,7 +332,14 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                code,
+                device_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_codes/unmanaged/get"
             )
@@ -363,7 +352,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -387,9 +376,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
         :param user_identifier_key: Your user ID for the user by which to filter unmanaged access codes.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -403,11 +390,6 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/list"
-            )
-
         res = self.client.get("/access_codes/unmanaged/list", params=params)
 
         return [
@@ -417,7 +399,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -440,8 +422,7 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
         :param force: Indicates whether to force the unmanaged access code update.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -457,11 +438,6 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
                 is_external_modification_allowed
             )
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/update"
-            )
-
         self.client.patch("/access_codes/unmanaged/update", json=json_payload)
 
         return None
@@ -474,7 +450,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/convert_to_managed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def convert_to_managed(
@@ -498,8 +474,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
         :param force: Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set ``force`` to ``true``.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the access code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -513,11 +488,6 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
                 is_external_modification_allowed
             )
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/convert_to_managed"
-            )
-
         await self.client.patch(
             "/access_codes/unmanaged/convert_to_managed", json=json_payload
         )
@@ -526,24 +496,18 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, access_code_id: str) -> None:
         """Deletes an `unmanaged access code <https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes>`_.
 
         :param access_code_id: ID of the unmanaged access code that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if access_code_id is not None:
             params["access_code_id"] = access_code_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/delete"
-            )
 
         await self.client.delete("/access_codes/unmanaged/delete", params=params)
 
@@ -551,7 +515,11 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "code",
+            "device_id",
+        ),
         has_pagination=False,
     )
     async def get(
@@ -583,7 +551,14 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                code,
+                device_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_codes/unmanaged/get"
             )
@@ -596,7 +571,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(
@@ -620,9 +595,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
         :param user_identifier_key: Your user ID for the user by which to filter unmanaged access codes.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -636,11 +609,6 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/list"
-            )
-
         res = await self.client.get("/access_codes/unmanaged/list", params=params)
 
         return [
@@ -650,7 +618,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
     @route_metadata(
         path="/access_codes/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -673,8 +641,7 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
         :param force: Indicates whether to force the unmanaged access code update.
 
         :param is_external_modification_allowed: Indicates whether `external modification <https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification>`_ of the code is allowed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_code_id is not None:
@@ -688,11 +655,6 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
         if is_external_modification_allowed is not None:
             json_payload["is_external_modification_allowed"] = (
                 is_external_modification_allowed
-            )
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_codes/unmanaged/update"
             )
 
         await self.client.patch("/access_codes/unmanaged/update", json=json_payload)

--- a/seam/routes/access_grants.py
+++ b/seam/routes/access_grants.py
@@ -73,18 +73,14 @@ class AbstractAccessGrants(abc.ABC):
 
         :param user_identity_id: ID of user identity for whom access is being granted.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def delete(self, *, access_grant_id: str) -> None:
         """Delete an Access Grant.
 
-        :param access_grant_id: ID of Access Grant to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param access_grant_id: ID of Access Grant to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -214,9 +210,7 @@ class AbstractAccessGrants(abc.ABC):
 
         :param requested_access_methods: Array of requested access methods to add to the access grant.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -304,18 +298,14 @@ class AbstractAsyncAccessGrants(abc.ABC):
 
         :param user_identity_id: ID of user identity for whom access is being granted.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def delete(self, *, access_grant_id: str) -> None:
         """Delete an Access Grant.
 
-        :param access_grant_id: ID of Access Grant to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param access_grant_id: ID of Access Grant to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -445,9 +435,7 @@ class AbstractAsyncAccessGrants(abc.ABC):
 
         :param requested_access_methods: Array of requested access methods to add to the access grant.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -487,7 +475,9 @@ class AccessGrants(AbstractAccessGrants):
         return self._unmanaged
 
     @route_metadata(
-        path="/access_grants/create", has_required_parameters=True, has_pagination=False
+        path="/access_grants/create",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def create(
         self,
@@ -540,9 +530,7 @@ class AccessGrants(AbstractAccessGrants):
 
         :param user_identity_id: ID of user identity for whom access is being granted.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if requested_access_methods is not None:
@@ -576,11 +564,6 @@ class AccessGrants(AbstractAccessGrants):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/create"
-            )
-
         res = self.client.post("/access_grants/create", json=json_payload)
 
         return AccessGrant.from_dict(
@@ -588,30 +571,30 @@ class AccessGrants(AbstractAccessGrants):
         )
 
     @route_metadata(
-        path="/access_grants/delete", has_required_parameters=True, has_pagination=False
+        path="/access_grants/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def delete(self, *, access_grant_id: str) -> None:
         """Delete an Access Grant.
 
-        :param access_grant_id: ID of Access Grant to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param access_grant_id: ID of Access Grant to delete."""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             params["access_grant_id"] = access_grant_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/delete"
-            )
 
         self.client.delete("/access_grants/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/access_grants/get", has_required_parameters=True, has_pagination=False
+        path="/access_grants/get",
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_grant_key",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -635,7 +618,13 @@ class AccessGrants(AbstractAccessGrants):
         if access_grant_key is not None:
             params["access_grant_key"] = access_grant_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_grant_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/get"
             )
@@ -646,7 +635,12 @@ class AccessGrants(AbstractAccessGrants):
 
     @route_metadata(
         path="/access_grants/get_related",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_grant_ids",
+            "access_grant_keys",
+            "exclude",
+            "include",
+        ),
         has_pagination=False,
     )
     def get_related(
@@ -707,7 +701,15 @@ class AccessGrants(AbstractAccessGrants):
         if include is not None:
             params["include"] = include
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_ids,
+                access_grant_keys,
+                exclude,
+                include,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/get_related"
             )
@@ -717,7 +719,7 @@ class AccessGrants(AbstractAccessGrants):
         return Batch.from_dict(unwrap(res, "batch", "/access_grants/get_related"))
 
     @route_metadata(
-        path="/access_grants/list", has_required_parameters=False, has_pagination=True
+        path="/access_grants/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -803,7 +805,7 @@ class AccessGrants(AbstractAccessGrants):
 
     @route_metadata(
         path="/access_grants/request_access_methods",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def request_access_methods(
@@ -815,20 +817,13 @@ class AccessGrants(AbstractAccessGrants):
 
         :param requested_access_methods: Array of requested access methods to add to the access grant.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             json_payload["access_grant_id"] = access_grant_id
         if requested_access_methods is not None:
             json_payload["requested_access_methods"] = requested_access_methods
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/request_access_methods"
-            )
 
         res = self.client.post(
             "/access_grants/request_access_methods", json=json_payload
@@ -839,7 +834,15 @@ class AccessGrants(AbstractAccessGrants):
         )
 
     @route_metadata(
-        path="/access_grants/update", has_required_parameters=True, has_pagination=False
+        path="/access_grants/update",
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_grant_key",
+            "ends_at",
+            "name",
+            "starts_at",
+        ),
+        has_pagination=False,
     )
     def update(
         self,
@@ -876,7 +879,16 @@ class AccessGrants(AbstractAccessGrants):
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_grant_key,
+                ends_at,
+                name,
+                starts_at,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/update"
             )
@@ -897,7 +909,9 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         return self._unmanaged
 
     @route_metadata(
-        path="/access_grants/create", has_required_parameters=True, has_pagination=False
+        path="/access_grants/create",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def create(
         self,
@@ -950,9 +964,7 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         :param user_identity_id: ID of user identity for whom access is being granted.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if requested_access_methods is not None:
@@ -986,11 +998,6 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/create"
-            )
-
         res = await self.client.post("/access_grants/create", json=json_payload)
 
         return AccessGrant.from_dict(
@@ -998,30 +1005,30 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         )
 
     @route_metadata(
-        path="/access_grants/delete", has_required_parameters=True, has_pagination=False
+        path="/access_grants/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def delete(self, *, access_grant_id: str) -> None:
         """Delete an Access Grant.
 
-        :param access_grant_id: ID of Access Grant to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param access_grant_id: ID of Access Grant to delete."""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             params["access_grant_id"] = access_grant_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/delete"
-            )
 
         await self.client.delete("/access_grants/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/access_grants/get", has_required_parameters=True, has_pagination=False
+        path="/access_grants/get",
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_grant_key",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -1045,7 +1052,13 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         if access_grant_key is not None:
             params["access_grant_key"] = access_grant_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_grant_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/get"
             )
@@ -1056,7 +1069,12 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
     @route_metadata(
         path="/access_grants/get_related",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_grant_ids",
+            "access_grant_keys",
+            "exclude",
+            "include",
+        ),
         has_pagination=False,
     )
     async def get_related(
@@ -1117,7 +1135,15 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         if include is not None:
             params["include"] = include
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_ids,
+                access_grant_keys,
+                exclude,
+                include,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/get_related"
             )
@@ -1127,7 +1153,7 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         return Batch.from_dict(unwrap(res, "batch", "/access_grants/get_related"))
 
     @route_metadata(
-        path="/access_grants/list", has_required_parameters=False, has_pagination=True
+        path="/access_grants/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -1213,7 +1239,7 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
     @route_metadata(
         path="/access_grants/request_access_methods",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def request_access_methods(
@@ -1225,20 +1251,13 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         :param requested_access_methods: Array of requested access methods to add to the access grant.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             json_payload["access_grant_id"] = access_grant_id
         if requested_access_methods is not None:
             json_payload["requested_access_methods"] = requested_access_methods
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/request_access_methods"
-            )
 
         res = await self.client.post(
             "/access_grants/request_access_methods", json=json_payload
@@ -1249,7 +1268,15 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         )
 
     @route_metadata(
-        path="/access_grants/update", has_required_parameters=True, has_pagination=False
+        path="/access_grants/update",
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_grant_key",
+            "ends_at",
+            "name",
+            "starts_at",
+        ),
+        has_pagination=False,
     )
     async def update(
         self,
@@ -1286,7 +1313,16 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_grant_key,
+                ends_at,
+                name,
+                starts_at,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_grants/update"
             )

--- a/seam/routes/access_grants_unmanaged.py
+++ b/seam/routes/access_grants_unmanaged.py
@@ -16,9 +16,7 @@ class AbstractAccessGrantsUnmanaged(abc.ABC):
 
         :param access_grant_id: ID of unmanaged Access Grant to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -68,8 +66,7 @@ class AbstractAccessGrantsUnmanaged(abc.ABC):
         :param is_managed: Must be set to true to convert the unmanaged access grant to managed.
 
         :param access_grant_key: Unique key for the access grant. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -81,9 +78,7 @@ class AbstractAsyncAccessGrantsUnmanaged(abc.ABC):
 
         :param access_grant_id: ID of unmanaged Access Grant to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -133,8 +128,7 @@ class AbstractAsyncAccessGrantsUnmanaged(abc.ABC):
         :param is_managed: Must be set to true to convert the unmanaged access grant to managed.
 
         :param access_grant_key: Unique key for the access grant. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -145,7 +139,7 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, access_grant_id: str) -> UnmanagedAccessGrant:
@@ -153,18 +147,11 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
         :param access_grant_id: ID of unmanaged Access Grant to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             params["access_grant_id"] = access_grant_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/unmanaged/get"
-            )
 
         res = self.client.get("/access_grants/unmanaged/get", params=params)
 
@@ -174,7 +161,7 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -228,7 +215,7 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -249,8 +236,7 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
         :param is_managed: Must be set to true to convert the unmanaged access grant to managed.
 
         :param access_grant_key: Unique key for the access grant. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_grant_id is not None:
@@ -259,11 +245,6 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
             json_payload["is_managed"] = is_managed
         if access_grant_key is not None:
             json_payload["access_grant_key"] = access_grant_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/unmanaged/update"
-            )
 
         self.client.patch("/access_grants/unmanaged/update", json=json_payload)
 
@@ -277,7 +258,7 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, access_grant_id: str) -> UnmanagedAccessGrant:
@@ -285,18 +266,11 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
         :param access_grant_id: ID of unmanaged Access Grant to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
             params["access_grant_id"] = access_grant_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/unmanaged/get"
-            )
 
         res = await self.client.get("/access_grants/unmanaged/get", params=params)
 
@@ -306,7 +280,7 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(
@@ -360,7 +334,7 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
     @route_metadata(
         path="/access_grants/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -381,8 +355,7 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
         :param is_managed: Must be set to true to convert the unmanaged access grant to managed.
 
         :param access_grant_key: Unique key for the access grant. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if access_grant_id is not None:
@@ -391,11 +364,6 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
             json_payload["is_managed"] = is_managed
         if access_grant_key is not None:
             json_payload["access_grant_key"] = access_grant_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_grants/unmanaged/update"
-            )
 
         await self.client.patch("/access_grants/unmanaged/update", json=json_payload)
 

--- a/seam/routes/access_methods.py
+++ b/seam/routes/access_methods.py
@@ -41,9 +41,7 @@ class AbstractAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -81,9 +79,7 @@ class AbstractAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -92,9 +88,7 @@ class AbstractAccessMethods(abc.ABC):
 
         :param access_method_id: ID of access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -139,9 +133,7 @@ class AbstractAccessMethods(abc.ABC):
 
         :param include:
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -196,9 +188,7 @@ class AbstractAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -225,9 +215,7 @@ class AbstractAsyncAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -265,9 +253,7 @@ class AbstractAsyncAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -276,9 +262,7 @@ class AbstractAsyncAccessMethods(abc.ABC):
 
         :param access_method_id: ID of access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -323,9 +307,7 @@ class AbstractAsyncAccessMethods(abc.ABC):
 
         :param include:
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -380,9 +362,7 @@ class AbstractAsyncAccessMethods(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -398,7 +378,7 @@ class AccessMethods(AbstractAccessMethods):
 
     @route_metadata(
         path="/access_methods/assign_card",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def assign_card(
@@ -416,20 +396,13 @@ class AccessMethods(AbstractAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if card_number is not None:
             json_payload["card_number"] = card_number
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/assign_card"
-            )
 
         res = self.client.post("/access_methods/assign_card", json=json_payload)
 
@@ -449,7 +422,11 @@ class AccessMethods(AbstractAccessMethods):
 
     @route_metadata(
         path="/access_methods/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_method_id",
+            "reservation_key",
+        ),
         has_pagination=False,
     )
     def delete(
@@ -477,7 +454,14 @@ class AccessMethods(AbstractAccessMethods):
         if reservation_key is not None:
             params["reservation_key"] = reservation_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_method_id,
+                reservation_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_methods/delete"
             )
@@ -488,7 +472,7 @@ class AccessMethods(AbstractAccessMethods):
 
     @route_metadata(
         path="/access_methods/encode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def encode(
@@ -506,20 +490,13 @@ class AccessMethods(AbstractAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/encode"
-            )
 
         res = self.client.post("/access_methods/encode", json=json_payload)
 
@@ -538,25 +515,20 @@ class AccessMethods(AbstractAccessMethods):
         )
 
     @route_metadata(
-        path="/access_methods/get", has_required_parameters=True, has_pagination=False
+        path="/access_methods/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def get(self, *, access_method_id: str) -> AccessMethod:
         """Gets an access method.
 
         :param access_method_id: ID of access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_id is not None:
             params["access_method_id"] = access_method_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/get"
-            )
 
         res = self.client.get("/access_methods/get", params=params)
 
@@ -566,7 +538,7 @@ class AccessMethods(AbstractAccessMethods):
 
     @route_metadata(
         path="/access_methods/get_related",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get_related(
@@ -610,9 +582,7 @@ class AccessMethods(AbstractAccessMethods):
 
         :param include:
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_ids is not None:
@@ -622,17 +592,21 @@ class AccessMethods(AbstractAccessMethods):
         if include is not None:
             params["include"] = include
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/get_related"
-            )
-
         res = self.client.get("/access_methods/get_related", params=params)
 
         return Batch.from_dict(unwrap(res, "batch", "/access_methods/get_related"))
 
     @route_metadata(
-        path="/access_methods/list", has_required_parameters=True, has_pagination=True
+        path="/access_methods/list",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "access_grant_id",
+            "access_grant_key",
+            "acs_entrance_id",
+            "device_id",
+            "space_id",
+        ),
+        has_pagination=True,
     )
     def list(
         self,
@@ -686,7 +660,17 @@ class AccessMethods(AbstractAccessMethods):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                access_grant_id,
+                access_grant_key,
+                acs_entrance_id,
+                device_id,
+                space_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_methods/list"
             )
@@ -700,7 +684,7 @@ class AccessMethods(AbstractAccessMethods):
 
     @route_metadata(
         path="/access_methods/unlock_door",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def unlock_door(
@@ -718,20 +702,13 @@ class AccessMethods(AbstractAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if acs_entrance_id is not None:
             json_payload["acs_entrance_id"] = acs_entrance_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unlock_door"
-            )
 
         res = self.client.post("/access_methods/unlock_door", json=json_payload)
 
@@ -762,7 +739,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
     @route_metadata(
         path="/access_methods/assign_card",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def assign_card(
@@ -780,20 +757,13 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if card_number is not None:
             json_payload["card_number"] = card_number
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/assign_card"
-            )
 
         res = await self.client.post("/access_methods/assign_card", json=json_payload)
 
@@ -813,7 +783,11 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
     @route_metadata(
         path="/access_methods/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "access_grant_id",
+            "access_method_id",
+            "reservation_key",
+        ),
         has_pagination=False,
     )
     async def delete(
@@ -841,7 +815,14 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
         if reservation_key is not None:
             params["reservation_key"] = reservation_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_grant_id,
+                access_method_id,
+                reservation_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_methods/delete"
             )
@@ -852,7 +833,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
     @route_metadata(
         path="/access_methods/encode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def encode(
@@ -870,20 +851,13 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/encode"
-            )
 
         res = await self.client.post("/access_methods/encode", json=json_payload)
 
@@ -902,25 +876,20 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
         )
 
     @route_metadata(
-        path="/access_methods/get", has_required_parameters=True, has_pagination=False
+        path="/access_methods/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def get(self, *, access_method_id: str) -> AccessMethod:
         """Gets an access method.
 
         :param access_method_id: ID of access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_id is not None:
             params["access_method_id"] = access_method_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/get"
-            )
 
         res = await self.client.get("/access_methods/get", params=params)
 
@@ -930,7 +899,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
     @route_metadata(
         path="/access_methods/get_related",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get_related(
@@ -974,9 +943,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         :param include:
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_ids is not None:
@@ -986,17 +953,21 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
         if include is not None:
             params["include"] = include
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/get_related"
-            )
-
         res = await self.client.get("/access_methods/get_related", params=params)
 
         return Batch.from_dict(unwrap(res, "batch", "/access_methods/get_related"))
 
     @route_metadata(
-        path="/access_methods/list", has_required_parameters=True, has_pagination=True
+        path="/access_methods/list",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "access_grant_id",
+            "access_grant_key",
+            "acs_entrance_id",
+            "device_id",
+            "space_id",
+        ),
+        has_pagination=True,
     )
     async def list(
         self,
@@ -1050,7 +1021,17 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                access_grant_id,
+                access_grant_key,
+                acs_entrance_id,
+                device_id,
+                space_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /access_methods/list"
             )
@@ -1064,7 +1045,7 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
     @route_metadata(
         path="/access_methods/unlock_door",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def unlock_door(
@@ -1082,20 +1063,13 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method_id is not None:
             json_payload["access_method_id"] = access_method_id
         if acs_entrance_id is not None:
             json_payload["acs_entrance_id"] = acs_entrance_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unlock_door"
-            )
 
         res = await self.client.post("/access_methods/unlock_door", json=json_payload)
 

--- a/seam/routes/access_methods_unmanaged.py
+++ b/seam/routes/access_methods_unmanaged.py
@@ -15,9 +15,7 @@ class AbstractAccessMethodsUnmanaged(abc.ABC):
 
         :param access_method_id: ID of unmanaged access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -39,9 +37,7 @@ class AbstractAccessMethodsUnmanaged(abc.ABC):
 
         :param space_id: ID of the space for which you want to retrieve all unmanaged access methods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -53,9 +49,7 @@ class AbstractAsyncAccessMethodsUnmanaged(abc.ABC):
 
         :param access_method_id: ID of unmanaged access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -77,9 +71,7 @@ class AbstractAsyncAccessMethodsUnmanaged(abc.ABC):
 
         :param space_id: ID of the space for which you want to retrieve all unmanaged access methods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -90,7 +82,7 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
     @route_metadata(
         path="/access_methods/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, access_method_id: str) -> UnmanagedAccessMethod:
@@ -98,18 +90,11 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
         :param access_method_id: ID of unmanaged access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_id is not None:
             params["access_method_id"] = access_method_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unmanaged/get"
-            )
 
         res = self.client.get("/access_methods/unmanaged/get", params=params)
 
@@ -119,7 +104,7 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
     @route_metadata(
         path="/access_methods/unmanaged/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list(
@@ -140,9 +125,7 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
 
         :param space_id: ID of the space for which you want to retrieve all unmanaged access methods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
@@ -153,11 +136,6 @@ class AccessMethodsUnmanaged(AbstractAccessMethodsUnmanaged):
             params["device_id"] = device_id
         if space_id is not None:
             params["space_id"] = space_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unmanaged/list"
-            )
 
         res = self.client.get("/access_methods/unmanaged/list", params=params)
 
@@ -176,7 +154,7 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
     @route_metadata(
         path="/access_methods/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, access_method_id: str) -> UnmanagedAccessMethod:
@@ -184,18 +162,11 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
         :param access_method_id: ID of unmanaged access method to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_method_id is not None:
             params["access_method_id"] = access_method_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unmanaged/get"
-            )
 
         res = await self.client.get("/access_methods/unmanaged/get", params=params)
 
@@ -205,7 +176,7 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
     @route_metadata(
         path="/access_methods/unmanaged/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list(
@@ -226,9 +197,7 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
 
         :param space_id: ID of the space for which you want to retrieve all unmanaged access methods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if access_grant_id is not None:
@@ -239,11 +208,6 @@ class AsyncAccessMethodsUnmanaged(AbstractAsyncAccessMethodsUnmanaged):
             params["device_id"] = device_id
         if space_id is not None:
             params["space_id"] = space_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /access_methods/unmanaged/list"
-            )
 
         res = await self.client.get("/access_methods/unmanaged/list", params=params)
 

--- a/seam/routes/acs_access_groups.py
+++ b/seam/routes/acs_access_groups.py
@@ -24,17 +24,14 @@ class AbstractAcsAccessGroups(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
     def delete(self, *, acs_access_group_id: str) -> None:
         """Deletes a specified `access group <https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups>`_.
 
-        :param acs_access_group_id: ID of the access group that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_access_group_id: ID of the access group that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -43,9 +40,7 @@ class AbstractAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -78,9 +73,7 @@ class AbstractAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -89,9 +82,7 @@ class AbstractAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -109,8 +100,7 @@ class AbstractAcsAccessGroups(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from an access group.
 
         :param user_identity_id: ID of the user identity associated with the user that you want to remove from an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -131,17 +121,14 @@ class AbstractAsyncAcsAccessGroups(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def delete(self, *, acs_access_group_id: str) -> None:
         """Deletes a specified `access group <https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups>`_.
 
-        :param acs_access_group_id: ID of the access group that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_access_group_id: ID of the access group that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -150,9 +137,7 @@ class AbstractAsyncAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -185,9 +170,7 @@ class AbstractAsyncAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -196,9 +179,7 @@ class AbstractAsyncAcsAccessGroups(abc.ABC):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -216,8 +197,7 @@ class AbstractAsyncAcsAccessGroups(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from an access group.
 
         :param user_identity_id: ID of the user identity associated with the user that you want to remove from an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -228,7 +208,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/add_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def add_user(
@@ -245,8 +225,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
         :param acs_user_id: ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -256,35 +235,23 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/add_user"
-            )
-
         self.client.put("/acs/access_groups/add_user", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/access_groups/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, acs_access_group_id: str) -> None:
         """Deletes a specified `access group <https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups>`_.
 
-        :param acs_access_group_id: ID of the access group that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_access_group_id: ID of the access group that you want to delete."""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/delete"
-            )
 
         self.client.delete("/acs/access_groups/delete", params=params)
 
@@ -292,7 +259,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, acs_access_group_id: str) -> AcsAccessGroup:
@@ -300,18 +267,11 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/get"
-            )
 
         res = self.client.get("/acs/access_groups/get", params=params)
 
@@ -321,7 +281,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list(
@@ -363,7 +323,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_accessible_entrances(
@@ -373,18 +333,11 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/list_accessible_entrances"
-            )
 
         res = self.client.get(
             "/acs/access_groups/list_accessible_entrances", params=params
@@ -399,7 +352,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list_users",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_users(self, *, acs_access_group_id: str) -> List[AcsUser]:
@@ -407,18 +360,11 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/list_users"
-            )
 
         res = self.client.get("/acs/access_groups/list_users", params=params)
 
@@ -429,7 +375,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/remove_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_user(
@@ -446,8 +392,7 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
         :param acs_user_id: ID of the access system user that you want to remove from an access group.
 
         :param user_identity_id: ID of the user identity associated with the user that you want to remove from an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -456,11 +401,6 @@ class AcsAccessGroups(AbstractAcsAccessGroups):
             params["acs_user_id"] = acs_user_id
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/remove_user"
-            )
 
         self.client.delete("/acs/access_groups/remove_user", params=params)
 
@@ -474,7 +414,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/add_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def add_user(
@@ -491,8 +431,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
         :param acs_user_id: ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -502,35 +441,23 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/add_user"
-            )
-
         await self.client.put("/acs/access_groups/add_user", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/access_groups/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, acs_access_group_id: str) -> None:
         """Deletes a specified `access group <https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups>`_.
 
-        :param acs_access_group_id: ID of the access group that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_access_group_id: ID of the access group that you want to delete."""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/delete"
-            )
 
         await self.client.delete("/acs/access_groups/delete", params=params)
 
@@ -538,7 +465,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, acs_access_group_id: str) -> AcsAccessGroup:
@@ -546,18 +473,11 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/get"
-            )
 
         res = await self.client.get("/acs/access_groups/get", params=params)
 
@@ -567,7 +487,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list(
@@ -609,7 +529,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_accessible_entrances(
@@ -619,18 +539,11 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/list_accessible_entrances"
-            )
 
         res = await self.client.get(
             "/acs/access_groups/list_accessible_entrances", params=params
@@ -645,7 +558,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/list_users",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_users(self, *, acs_access_group_id: str) -> List[AcsUser]:
@@ -653,18 +566,11 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
         :param acs_access_group_id: ID of the access group for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
             params["acs_access_group_id"] = acs_access_group_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/list_users"
-            )
 
         res = await self.client.get("/acs/access_groups/list_users", params=params)
 
@@ -675,7 +581,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
 
     @route_metadata(
         path="/acs/access_groups/remove_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_user(
@@ -692,8 +598,7 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
         :param acs_user_id: ID of the access system user that you want to remove from an access group.
 
         :param user_identity_id: ID of the user identity associated with the user that you want to remove from an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -702,11 +607,6 @@ class AsyncAcsAccessGroups(AbstractAsyncAcsAccessGroups):
             params["acs_user_id"] = acs_user_id
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/access_groups/remove_user"
-            )
 
         await self.client.delete("/acs/access_groups/remove_user", params=params)
 

--- a/seam/routes/acs_credentials.py
+++ b/seam/routes/acs_credentials.py
@@ -25,8 +25,7 @@ class AbstractAcsCredentials(abc.ABC):
         :param acs_user_id: ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -75,18 +74,14 @@ class AbstractAcsCredentials(abc.ABC):
 
         :param visionline_metadata: Visionline-specific metadata for the new credential.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def delete(self, *, acs_credential_id: str) -> None:
         """Deletes a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
-        :param acs_credential_id: ID of the credential that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_credential_id: ID of the credential that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -95,9 +90,7 @@ class AbstractAcsCredentials(abc.ABC):
 
         :param acs_credential_id: ID of the credential that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -140,9 +133,7 @@ class AbstractAcsCredentials(abc.ABC):
 
         :param acs_credential_id: ID of the credential for which you want to retrieve all entrances to which the credential grants access.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -160,8 +151,7 @@ class AbstractAcsCredentials(abc.ABC):
         :param acs_user_id: ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -179,8 +169,7 @@ class AbstractAcsCredentials(abc.ABC):
         :param code: Replacement access (PIN) code for the credential that you want to update.
 
         :param ends_at: Replacement date and time at which the validity of the credential ends, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format. Must be a time in the future and after the ``starts_at`` value that you set when creating the credential.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -201,8 +190,7 @@ class AbstractAsyncAcsCredentials(abc.ABC):
         :param acs_user_id: ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -251,18 +239,14 @@ class AbstractAsyncAcsCredentials(abc.ABC):
 
         :param visionline_metadata: Visionline-specific metadata for the new credential.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def delete(self, *, acs_credential_id: str) -> None:
         """Deletes a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
-        :param acs_credential_id: ID of the credential that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_credential_id: ID of the credential that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -271,9 +255,7 @@ class AbstractAsyncAcsCredentials(abc.ABC):
 
         :param acs_credential_id: ID of the credential that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -318,9 +300,7 @@ class AbstractAsyncAcsCredentials(abc.ABC):
 
         :param acs_credential_id: ID of the credential for which you want to retrieve all entrances to which the credential grants access.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -338,8 +318,7 @@ class AbstractAsyncAcsCredentials(abc.ABC):
         :param acs_user_id: ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -357,8 +336,7 @@ class AbstractAsyncAcsCredentials(abc.ABC):
         :param code: Replacement access (PIN) code for the credential that you want to update.
 
         :param ends_at: Replacement date and time at which the validity of the credential ends, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format. Must be a time in the future and after the ``starts_at`` value that you set when creating the credential.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -369,7 +347,7 @@ class AcsCredentials(AbstractAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/assign",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def assign(
@@ -386,8 +364,7 @@ class AcsCredentials(AbstractAcsCredentials):
         :param acs_user_id: ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -397,18 +374,13 @@ class AcsCredentials(AbstractAcsCredentials):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/assign"
-            )
-
         self.client.patch("/acs/credentials/assign", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/credentials/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -456,9 +428,7 @@ class AcsCredentials(AbstractAcsCredentials):
 
         :param visionline_metadata: Visionline-specific metadata for the new credential.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method is not None:
@@ -492,11 +462,6 @@ class AcsCredentials(AbstractAcsCredentials):
         if visionline_metadata is not None:
             json_payload["visionline_metadata"] = visionline_metadata
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/create"
-            )
-
         res = self.client.post("/acs/credentials/create", json=json_payload)
 
         return AcsCredential.from_dict(
@@ -505,49 +470,37 @@ class AcsCredentials(AbstractAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, acs_credential_id: str) -> None:
         """Deletes a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
-        :param acs_credential_id: ID of the credential that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_credential_id: ID of the credential that you want to delete."""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/delete"
-            )
 
         self.client.delete("/acs/credentials/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/acs/credentials/get", has_required_parameters=True, has_pagination=False
+        path="/acs/credentials/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def get(self, *, acs_credential_id: str) -> AcsCredential:
         """Returns a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
         :param acs_credential_id: ID of the credential that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/get"
-            )
 
         res = self.client.get("/acs/credentials/get", params=params)
 
@@ -556,7 +509,9 @@ class AcsCredentials(AbstractAcsCredentials):
         )
 
     @route_metadata(
-        path="/acs/credentials/list", has_required_parameters=False, has_pagination=True
+        path="/acs/credentials/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     def list(
         self,
@@ -617,7 +572,7 @@ class AcsCredentials(AbstractAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_accessible_entrances(self, *, acs_credential_id: str) -> List[AcsEntrance]:
@@ -625,18 +580,11 @@ class AcsCredentials(AbstractAcsCredentials):
 
         :param acs_credential_id: ID of the credential for which you want to retrieve all entrances to which the credential grants access.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/list_accessible_entrances"
-            )
 
         res = self.client.get(
             "/acs/credentials/list_accessible_entrances", params=params
@@ -651,7 +599,7 @@ class AcsCredentials(AbstractAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/unassign",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def unassign(
@@ -668,8 +616,7 @@ class AcsCredentials(AbstractAcsCredentials):
         :param acs_user_id: ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -679,18 +626,13 @@ class AcsCredentials(AbstractAcsCredentials):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/unassign"
-            )
-
         self.client.patch("/acs/credentials/unassign", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/credentials/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -707,8 +649,7 @@ class AcsCredentials(AbstractAcsCredentials):
         :param code: Replacement access (PIN) code for the credential that you want to update.
 
         :param ends_at: Replacement date and time at which the validity of the credential ends, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format. Must be a time in the future and after the ``starts_at`` value that you set when creating the credential.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -717,11 +658,6 @@ class AcsCredentials(AbstractAcsCredentials):
             json_payload["code"] = code
         if ends_at is not None:
             json_payload["ends_at"] = ends_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/update"
-            )
 
         self.client.patch("/acs/credentials/update", json=json_payload)
 
@@ -735,7 +671,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/assign",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def assign(
@@ -752,8 +688,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         :param acs_user_id: ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -763,18 +698,13 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/assign"
-            )
-
         await self.client.patch("/acs/credentials/assign", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/credentials/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -822,9 +752,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         :param visionline_metadata: Visionline-specific metadata for the new credential.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if access_method is not None:
@@ -858,11 +786,6 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         if visionline_metadata is not None:
             json_payload["visionline_metadata"] = visionline_metadata
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/create"
-            )
-
         res = await self.client.post("/acs/credentials/create", json=json_payload)
 
         return AcsCredential.from_dict(
@@ -871,49 +794,37 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, acs_credential_id: str) -> None:
         """Deletes a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
-        :param acs_credential_id: ID of the credential that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_credential_id: ID of the credential that you want to delete."""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/delete"
-            )
 
         await self.client.delete("/acs/credentials/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/acs/credentials/get", has_required_parameters=True, has_pagination=False
+        path="/acs/credentials/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def get(self, *, acs_credential_id: str) -> AcsCredential:
         """Returns a specified `credential <https://docs.seam.co/low-level-apis/access-systems/managing-credentials>`_.
 
         :param acs_credential_id: ID of the credential that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/get"
-            )
 
         res = await self.client.get("/acs/credentials/get", params=params)
 
@@ -922,7 +833,9 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         )
 
     @route_metadata(
-        path="/acs/credentials/list", has_required_parameters=False, has_pagination=True
+        path="/acs/credentials/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     async def list(
         self,
@@ -983,7 +896,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_accessible_entrances(
@@ -993,18 +906,11 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         :param acs_credential_id: ID of the credential for which you want to retrieve all entrances to which the credential grants access.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             params["acs_credential_id"] = acs_credential_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/list_accessible_entrances"
-            )
 
         res = await self.client.get(
             "/acs/credentials/list_accessible_entrances", params=params
@@ -1019,7 +925,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
     @route_metadata(
         path="/acs/credentials/unassign",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def unassign(
@@ -1036,8 +942,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         :param acs_user_id: ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -1047,18 +952,13 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/unassign"
-            )
-
         await self.client.patch("/acs/credentials/unassign", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/acs/credentials/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -1075,8 +975,7 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
         :param code: Replacement access (PIN) code for the credential that you want to update.
 
         :param ends_at: Replacement date and time at which the validity of the credential ends, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format. Must be a time in the future and after the ``starts_at`` value that you set when creating the credential.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
@@ -1085,11 +984,6 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
             json_payload["code"] = code
         if ends_at is not None:
             json_payload["ends_at"] = ends_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/credentials/update"
-            )
 
         await self.client.patch("/acs/credentials/update", json=json_payload)
 

--- a/seam/routes/acs_encoders.py
+++ b/seam/routes/acs_encoders.py
@@ -44,9 +44,7 @@ class AbstractAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -55,9 +53,7 @@ class AbstractAcsEncoders(abc.ABC):
 
         :param acs_encoder_id: ID of the encoder that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -101,9 +97,7 @@ class AbstractAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -128,9 +122,7 @@ class AbstractAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -160,9 +152,7 @@ class AbstractAsyncAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -171,9 +161,7 @@ class AbstractAsyncAcsEncoders(abc.ABC):
 
         :param acs_encoder_id: ID of the encoder that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -217,9 +205,7 @@ class AbstractAsyncAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -244,9 +230,7 @@ class AbstractAsyncAcsEncoders(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -262,7 +246,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/encode_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def encode_credential(
@@ -283,9 +267,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -294,11 +276,6 @@ class AcsEncoders(AbstractAcsEncoders):
             json_payload["access_method_id"] = access_method_id
         if acs_credential_id is not None:
             json_payload["acs_credential_id"] = acs_credential_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/encode_credential"
-            )
 
         res = self.client.post("/acs/encoders/encode_credential", json=json_payload)
 
@@ -317,30 +294,25 @@ class AcsEncoders(AbstractAcsEncoders):
         )
 
     @route_metadata(
-        path="/acs/encoders/get", has_required_parameters=True, has_pagination=False
+        path="/acs/encoders/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self, *, acs_encoder_id: str) -> AcsEncoder:
         """Returns a specified `encoder <https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners>`_.
 
         :param acs_encoder_id: ID of the encoder that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             params["acs_encoder_id"] = acs_encoder_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /acs/encoders/get")
 
         res = self.client.get("/acs/encoders/get", params=params)
 
         return AcsEncoder.from_dict(unwrap(res, "acs_encoder", "/acs/encoders/get"))
 
     @route_metadata(
-        path="/acs/encoders/list", has_required_parameters=False, has_pagination=True
+        path="/acs/encoders/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -386,7 +358,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/scan_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def scan_credential(
@@ -404,20 +376,13 @@ class AcsEncoders(AbstractAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
         if salto_ks_metadata is not None:
             json_payload["salto_ks_metadata"] = salto_ks_metadata
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/scan_credential"
-            )
 
         res = self.client.post("/acs/encoders/scan_credential", json=json_payload)
 
@@ -437,7 +402,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/scan_to_assign_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def scan_to_assign_credential(
@@ -461,9 +426,7 @@ class AcsEncoders(AbstractAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -474,11 +437,6 @@ class AcsEncoders(AbstractAcsEncoders):
             json_payload["salto_ks_metadata"] = salto_ks_metadata
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/scan_to_assign_credential"
-            )
 
         res = self.client.post(
             "/acs/encoders/scan_to_assign_credential", json=json_payload
@@ -511,7 +469,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/encode_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def encode_credential(
@@ -532,9 +490,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -543,11 +499,6 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
             json_payload["access_method_id"] = access_method_id
         if acs_credential_id is not None:
             json_payload["acs_credential_id"] = acs_credential_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/encode_credential"
-            )
 
         res = await self.client.post(
             "/acs/encoders/encode_credential", json=json_payload
@@ -568,30 +519,25 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
         )
 
     @route_metadata(
-        path="/acs/encoders/get", has_required_parameters=True, has_pagination=False
+        path="/acs/encoders/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self, *, acs_encoder_id: str) -> AcsEncoder:
         """Returns a specified `encoder <https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners>`_.
 
         :param acs_encoder_id: ID of the encoder that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             params["acs_encoder_id"] = acs_encoder_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /acs/encoders/get")
 
         res = await self.client.get("/acs/encoders/get", params=params)
 
         return AcsEncoder.from_dict(unwrap(res, "acs_encoder", "/acs/encoders/get"))
 
     @route_metadata(
-        path="/acs/encoders/list", has_required_parameters=False, has_pagination=True
+        path="/acs/encoders/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -637,7 +583,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/scan_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def scan_credential(
@@ -655,20 +601,13 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
         if salto_ks_metadata is not None:
             json_payload["salto_ks_metadata"] = salto_ks_metadata
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/scan_credential"
-            )
 
         res = await self.client.post("/acs/encoders/scan_credential", json=json_payload)
 
@@ -688,7 +627,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
     @route_metadata(
         path="/acs/encoders/scan_to_assign_credential",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def scan_to_assign_credential(
@@ -712,9 +651,7 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -725,11 +662,6 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
             json_payload["salto_ks_metadata"] = salto_ks_metadata
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/scan_to_assign_credential"
-            )
 
         res = await self.client.post(
             "/acs/encoders/scan_to_assign_credential", json=json_payload

--- a/seam/routes/acs_encoders_simulate.py
+++ b/seam/routes/acs_encoders_simulate.py
@@ -27,9 +27,7 @@ class AbstractAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id: ID of the ``acs_credential`` that will fail to be encoded onto a card in the next request.
 
-        :param error_code: Code of the error to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code: Code of the error to simulate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -43,9 +41,7 @@ class AbstractAcsEncodersSimulate(abc.ABC):
 
         :param acs_encoder_id: ID of the ``acs_encoder`` that will be used in the next request to encode the ``acs_credential``.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -68,9 +64,7 @@ class AbstractAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id_on_seam:
 
-        :param error_code:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code:"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -94,9 +88,7 @@ class AbstractAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id_on_seam: ID of the Seam ``acs_credential`` that matches the ``acs_credential`` on the encoder in this simulation.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         raise NotImplementedError()
 
 
@@ -123,9 +115,7 @@ class AbstractAsyncAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id: ID of the ``acs_credential`` that will fail to be encoded onto a card in the next request.
 
-        :param error_code: Code of the error to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code: Code of the error to simulate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -139,9 +129,7 @@ class AbstractAsyncAcsEncodersSimulate(abc.ABC):
 
         :param acs_encoder_id: ID of the ``acs_encoder`` that will be used in the next request to encode the ``acs_credential``.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -164,9 +152,7 @@ class AbstractAsyncAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id_on_seam:
 
-        :param error_code:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code:"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -190,9 +176,7 @@ class AbstractAsyncAcsEncodersSimulate(abc.ABC):
 
         :param acs_credential_id_on_seam: ID of the Seam ``acs_credential`` that matches the ``acs_credential`` on the encoder in this simulation.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         raise NotImplementedError()
 
 
@@ -203,7 +187,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_encode_will_fail",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def next_credential_encode_will_fail(
@@ -226,9 +210,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
         :param acs_credential_id: ID of the ``acs_credential`` that will fail to be encoded onto a card in the next request.
 
-        :param error_code: Code of the error to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code: Code of the error to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -238,11 +220,6 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
         if error_code is not None:
             json_payload["error_code"] = error_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_encode_will_fail"
-            )
-
         self.client.post(
             "/acs/encoders/simulate/next_credential_encode_will_fail", json=json_payload
         )
@@ -251,7 +228,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_encode_will_succeed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def next_credential_encode_will_succeed(
@@ -264,20 +241,13 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
         :param acs_encoder_id: ID of the ``acs_encoder`` that will be used in the next request to encode the ``acs_credential``.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
         if scenario is not None:
             json_payload["scenario"] = scenario
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_encode_will_succeed"
-            )
 
         self.client.post(
             "/acs/encoders/simulate/next_credential_encode_will_succeed",
@@ -288,7 +258,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_scan_will_fail",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def next_credential_scan_will_fail(
@@ -310,9 +280,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
         :param acs_credential_id_on_seam:
 
-        :param error_code:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code:"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -322,11 +290,6 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
         if error_code is not None:
             json_payload["error_code"] = error_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_scan_will_fail"
-            )
-
         self.client.post(
             "/acs/encoders/simulate/next_credential_scan_will_fail", json=json_payload
         )
@@ -335,7 +298,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_scan_will_succeed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def next_credential_scan_will_succeed(
@@ -358,9 +321,7 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
 
         :param acs_credential_id_on_seam: ID of the Seam ``acs_credential`` that matches the ``acs_credential`` on the encoder in this simulation.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -369,11 +330,6 @@ class AcsEncodersSimulate(AbstractAcsEncodersSimulate):
             json_payload["acs_credential_id_on_seam"] = acs_credential_id_on_seam
         if scenario is not None:
             json_payload["scenario"] = scenario
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_scan_will_succeed"
-            )
 
         self.client.post(
             "/acs/encoders/simulate/next_credential_scan_will_succeed",
@@ -390,7 +346,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_encode_will_fail",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def next_credential_encode_will_fail(
@@ -413,9 +369,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
         :param acs_credential_id: ID of the ``acs_credential`` that will fail to be encoded onto a card in the next request.
 
-        :param error_code: Code of the error to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code: Code of the error to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -425,11 +379,6 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
         if error_code is not None:
             json_payload["error_code"] = error_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_encode_will_fail"
-            )
-
         await self.client.post(
             "/acs/encoders/simulate/next_credential_encode_will_fail", json=json_payload
         )
@@ -438,7 +387,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_encode_will_succeed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def next_credential_encode_will_succeed(
@@ -451,20 +400,13 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
         :param acs_encoder_id: ID of the ``acs_encoder`` that will be used in the next request to encode the ``acs_credential``.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
             json_payload["acs_encoder_id"] = acs_encoder_id
         if scenario is not None:
             json_payload["scenario"] = scenario
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_encode_will_succeed"
-            )
 
         await self.client.post(
             "/acs/encoders/simulate/next_credential_encode_will_succeed",
@@ -475,7 +417,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_scan_will_fail",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def next_credential_scan_will_fail(
@@ -497,9 +439,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
         :param acs_credential_id_on_seam:
 
-        :param error_code:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param error_code:"""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -509,11 +449,6 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
         if error_code is not None:
             json_payload["error_code"] = error_code
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_scan_will_fail"
-            )
-
         await self.client.post(
             "/acs/encoders/simulate/next_credential_scan_will_fail", json=json_payload
         )
@@ -522,7 +457,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
     @route_metadata(
         path="/acs/encoders/simulate/next_credential_scan_will_succeed",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def next_credential_scan_will_succeed(
@@ -545,9 +480,7 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
 
         :param acs_credential_id_on_seam: ID of the Seam ``acs_credential`` that matches the ``acs_credential`` on the encoder in this simulation.
 
-        :param scenario: Scenario to simulate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param scenario: Scenario to simulate."""
         json_payload: Dict[str, Any] = {}
 
         if acs_encoder_id is not None:
@@ -556,11 +489,6 @@ class AsyncAcsEncodersSimulate(AbstractAsyncAcsEncodersSimulate):
             json_payload["acs_credential_id_on_seam"] = acs_credential_id_on_seam
         if scenario is not None:
             json_payload["scenario"] = scenario
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/encoders/simulate/next_credential_scan_will_succeed"
-            )
 
         await self.client.post(
             "/acs/encoders/simulate/next_credential_scan_will_succeed",

--- a/seam/routes/acs_entrances.py
+++ b/seam/routes/acs_entrances.py
@@ -25,9 +25,7 @@ class AbstractAcsEntrances(abc.ABC):
 
         :param acs_entrance_id: ID of the entrance that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -45,8 +43,7 @@ class AbstractAcsEntrances(abc.ABC):
         :param acs_user_id: ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -105,9 +102,7 @@ class AbstractAcsEntrances(abc.ABC):
 
         :param include_if: Conditions that credentials must meet to be included in the returned list.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -126,9 +121,7 @@ class AbstractAcsEntrances(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -140,9 +133,7 @@ class AbstractAsyncAcsEntrances(abc.ABC):
 
         :param acs_entrance_id: ID of the entrance that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -160,8 +151,7 @@ class AbstractAsyncAcsEntrances(abc.ABC):
         :param acs_user_id: ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -220,9 +210,7 @@ class AbstractAsyncAcsEntrances(abc.ABC):
 
         :param include_if: Conditions that credentials must meet to be included in the returned list.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -241,9 +229,7 @@ class AbstractAsyncAcsEntrances(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -253,25 +239,18 @@ class AcsEntrances(AbstractAcsEntrances):
         self.defaults = defaults
 
     @route_metadata(
-        path="/acs/entrances/get", has_required_parameters=True, has_pagination=False
+        path="/acs/entrances/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self, *, acs_entrance_id: str) -> AcsEntrance:
         """Returns a specified `access system entrance <https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details>`_.
 
         :param acs_entrance_id: ID of the entrance that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
             params["acs_entrance_id"] = acs_entrance_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/get"
-            )
 
         res = self.client.get("/acs/entrances/get", params=params)
 
@@ -279,7 +258,7 @@ class AcsEntrances(AbstractAcsEntrances):
 
     @route_metadata(
         path="/acs/entrances/grant_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def grant_access(
@@ -296,8 +275,7 @@ class AcsEntrances(AbstractAcsEntrances):
         :param acs_user_id: ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
@@ -307,17 +285,12 @@ class AcsEntrances(AbstractAcsEntrances):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/grant_access"
-            )
-
         self.client.post("/acs/entrances/grant_access", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/acs/entrances/list", has_required_parameters=False, has_pagination=True
+        path="/acs/entrances/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -393,7 +366,7 @@ class AcsEntrances(AbstractAcsEntrances):
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_credentials_with_access(
@@ -408,20 +381,13 @@ class AcsEntrances(AbstractAcsEntrances):
 
         :param include_if: Conditions that credentials must meet to be included in the returned list.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
             params["acs_entrance_id"] = acs_entrance_id
         if include_if is not None:
             params["include_if"] = include_if
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/list_credentials_with_access"
-            )
 
         res = self.client.get(
             "/acs/entrances/list_credentials_with_access", params=params
@@ -435,7 +401,9 @@ class AcsEntrances(AbstractAcsEntrances):
         ]
 
     @route_metadata(
-        path="/acs/entrances/unlock", has_required_parameters=True, has_pagination=False
+        path="/acs/entrances/unlock",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def unlock(
         self,
@@ -452,20 +420,13 @@ class AcsEntrances(AbstractAcsEntrances):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             json_payload["acs_credential_id"] = acs_credential_id
         if acs_entrance_id is not None:
             json_payload["acs_entrance_id"] = acs_entrance_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/unlock"
-            )
 
         res = self.client.post("/acs/entrances/unlock", json=json_payload)
 
@@ -490,25 +451,18 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
         self.defaults = defaults
 
     @route_metadata(
-        path="/acs/entrances/get", has_required_parameters=True, has_pagination=False
+        path="/acs/entrances/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self, *, acs_entrance_id: str) -> AcsEntrance:
         """Returns a specified `access system entrance <https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details>`_.
 
         :param acs_entrance_id: ID of the entrance that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
             params["acs_entrance_id"] = acs_entrance_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/get"
-            )
 
         res = await self.client.get("/acs/entrances/get", params=params)
 
@@ -516,7 +470,7 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
     @route_metadata(
         path="/acs/entrances/grant_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def grant_access(
@@ -533,8 +487,7 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
         :param acs_user_id: ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same ``email_address`` or ``phone_number`` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
@@ -544,17 +497,12 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/grant_access"
-            )
-
         await self.client.post("/acs/entrances/grant_access", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/acs/entrances/list", has_required_parameters=False, has_pagination=True
+        path="/acs/entrances/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -630,7 +578,7 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_credentials_with_access(
@@ -645,20 +593,13 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         :param include_if: Conditions that credentials must meet to be included in the returned list.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_entrance_id is not None:
             params["acs_entrance_id"] = acs_entrance_id
         if include_if is not None:
             params["include_if"] = include_if
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/list_credentials_with_access"
-            )
 
         res = await self.client.get(
             "/acs/entrances/list_credentials_with_access", params=params
@@ -672,7 +613,9 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
         ]
 
     @route_metadata(
-        path="/acs/entrances/unlock", has_required_parameters=True, has_pagination=False
+        path="/acs/entrances/unlock",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def unlock(
         self,
@@ -689,20 +632,13 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_credential_id is not None:
             json_payload["acs_credential_id"] = acs_credential_id
         if acs_entrance_id is not None:
             json_payload["acs_entrance_id"] = acs_entrance_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/entrances/unlock"
-            )
 
         res = await self.client.post("/acs/entrances/unlock", json=json_payload)
 

--- a/seam/routes/acs_systems.py
+++ b/seam/routes/acs_systems.py
@@ -15,9 +15,7 @@ class AbstractAcsSystems(abc.ABC):
 
         :param acs_system_id: ID of the access system that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -51,9 +49,7 @@ class AbstractAcsSystems(abc.ABC):
 
         :param acs_system_id: ID of the access system for which you want to retrieve all compatible credential manager systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -70,9 +66,7 @@ class AbstractAcsSystems(abc.ABC):
 
         :param acs_encoders: Array of ACS encoders to report
 
-        :param acs_entrances: Array of ACS entrances to report
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_entrances: Array of ACS entrances to report"""
         raise NotImplementedError()
 
 
@@ -84,9 +78,7 @@ class AbstractAsyncAcsSystems(abc.ABC):
 
         :param acs_system_id: ID of the access system that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -120,9 +112,7 @@ class AbstractAsyncAcsSystems(abc.ABC):
 
         :param acs_system_id: ID of the access system for which you want to retrieve all compatible credential manager systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -139,9 +129,7 @@ class AbstractAsyncAcsSystems(abc.ABC):
 
         :param acs_encoders: Array of ACS encoders to report
 
-        :param acs_entrances: Array of ACS entrances to report
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_entrances: Array of ACS entrances to report"""
         raise NotImplementedError()
 
 
@@ -151,30 +139,25 @@ class AcsSystems(AbstractAcsSystems):
         self.defaults = defaults
 
     @route_metadata(
-        path="/acs/systems/get", has_required_parameters=True, has_pagination=False
+        path="/acs/systems/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self, *, acs_system_id: str) -> AcsSystem:
         """Returns a specified `access system <https://docs.seam.co/low-level-apis/access-systems>`_.
 
         :param acs_system_id: ID of the access system that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_system_id is not None:
             params["acs_system_id"] = acs_system_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /acs/systems/get")
 
         res = self.client.get("/acs/systems/get", params=params)
 
         return AcsSystem.from_dict(unwrap(res, "acs_system", "/acs/systems/get"))
 
     @route_metadata(
-        path="/acs/systems/list", has_required_parameters=False, has_pagination=False
+        path="/acs/systems/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(
         self,
@@ -212,7 +195,7 @@ class AcsSystems(AbstractAcsSystems):
 
     @route_metadata(
         path="/acs/systems/list_compatible_credential_manager_acs_systems",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_compatible_credential_manager_acs_systems(
@@ -224,18 +207,11 @@ class AcsSystems(AbstractAcsSystems):
 
         :param acs_system_id: ID of the access system for which you want to retrieve all compatible credential manager systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_system_id is not None:
             params["acs_system_id"] = acs_system_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/systems/list_compatible_credential_manager_acs_systems"
-            )
 
         res = self.client.get(
             "/acs/systems/list_compatible_credential_manager_acs_systems", params=params
@@ -252,7 +228,7 @@ class AcsSystems(AbstractAcsSystems):
 
     @route_metadata(
         path="/acs/systems/report_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def report_devices(
@@ -268,9 +244,7 @@ class AcsSystems(AbstractAcsSystems):
 
         :param acs_encoders: Array of ACS encoders to report
 
-        :param acs_entrances: Array of ACS entrances to report
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_entrances: Array of ACS entrances to report"""
         json_payload: Dict[str, Any] = {}
 
         if acs_system_id is not None:
@@ -279,11 +253,6 @@ class AcsSystems(AbstractAcsSystems):
             json_payload["acs_encoders"] = acs_encoders
         if acs_entrances is not None:
             json_payload["acs_entrances"] = acs_entrances
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/systems/report_devices"
-            )
 
         self.client.post("/acs/systems/report_devices", json=json_payload)
 
@@ -296,30 +265,25 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
         self.defaults = defaults
 
     @route_metadata(
-        path="/acs/systems/get", has_required_parameters=True, has_pagination=False
+        path="/acs/systems/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self, *, acs_system_id: str) -> AcsSystem:
         """Returns a specified `access system <https://docs.seam.co/low-level-apis/access-systems>`_.
 
         :param acs_system_id: ID of the access system that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_system_id is not None:
             params["acs_system_id"] = acs_system_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /acs/systems/get")
 
         res = await self.client.get("/acs/systems/get", params=params)
 
         return AcsSystem.from_dict(unwrap(res, "acs_system", "/acs/systems/get"))
 
     @route_metadata(
-        path="/acs/systems/list", has_required_parameters=False, has_pagination=False
+        path="/acs/systems/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(
         self,
@@ -357,7 +321,7 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
     @route_metadata(
         path="/acs/systems/list_compatible_credential_manager_acs_systems",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_compatible_credential_manager_acs_systems(
@@ -369,18 +333,11 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
         :param acs_system_id: ID of the access system for which you want to retrieve all compatible credential manager systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if acs_system_id is not None:
             params["acs_system_id"] = acs_system_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/systems/list_compatible_credential_manager_acs_systems"
-            )
 
         res = await self.client.get(
             "/acs/systems/list_compatible_credential_manager_acs_systems", params=params
@@ -397,7 +354,7 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
     @route_metadata(
         path="/acs/systems/report_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def report_devices(
@@ -413,9 +370,7 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
 
         :param acs_encoders: Array of ACS encoders to report
 
-        :param acs_entrances: Array of ACS entrances to report
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param acs_entrances: Array of ACS entrances to report"""
         json_payload: Dict[str, Any] = {}
 
         if acs_system_id is not None:
@@ -424,11 +379,6 @@ class AsyncAcsSystems(AbstractAsyncAcsSystems):
             json_payload["acs_encoders"] = acs_encoders
         if acs_entrances is not None:
             json_payload["acs_entrances"] = acs_entrances
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/systems/report_devices"
-            )
 
         await self.client.post("/acs/systems/report_devices", json=json_payload)
 

--- a/seam/routes/acs_users.py
+++ b/seam/routes/acs_users.py
@@ -19,8 +19,7 @@ class AbstractAcsUsers(abc.ABC):
         :param acs_access_group_id: ID of the access group to which you want to add an access system user.
 
         :param acs_user_id: ID of the access system user that you want to add to an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -54,9 +53,7 @@ class AbstractAcsUsers(abc.ABC):
 
         :param user_identity_id: ID of the user identity with which you want to associate the new access system user.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -169,8 +166,7 @@ class AbstractAcsUsers(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -279,8 +275,7 @@ class AbstractAsyncAcsUsers(abc.ABC):
         :param acs_access_group_id: ID of the access group to which you want to add an access system user.
 
         :param acs_user_id: ID of the access system user that you want to add to an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -314,9 +309,7 @@ class AbstractAsyncAcsUsers(abc.ABC):
 
         :param user_identity_id: ID of the user identity with which you want to associate the new access system user.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -429,8 +422,7 @@ class AbstractAsyncAcsUsers(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -535,7 +527,7 @@ class AcsUsers(AbstractAcsUsers):
 
     @route_metadata(
         path="/acs/users/add_to_access_group",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def add_to_access_group(
@@ -546,8 +538,7 @@ class AcsUsers(AbstractAcsUsers):
         :param acs_access_group_id: ID of the access group to which you want to add an access system user.
 
         :param acs_user_id: ID of the access system user that you want to add to an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -555,17 +546,12 @@ class AcsUsers(AbstractAcsUsers):
         if acs_user_id is not None:
             json_payload["acs_user_id"] = acs_user_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/users/add_to_access_group"
-            )
-
         self.client.put("/acs/users/add_to_access_group", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/acs/users/create", has_required_parameters=True, has_pagination=False
+        path="/acs/users/create", at_least_one_parameter_names=(), has_pagination=False
     )
     def create(
         self,
@@ -597,9 +583,7 @@ class AcsUsers(AbstractAcsUsers):
 
         :param user_identity_id: ID of the user identity with which you want to associate the new access system user.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_system_id is not None:
@@ -619,15 +603,18 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /acs/users/create")
-
         res = self.client.post("/acs/users/create", json=json_payload)
 
         return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/create"))
 
     @route_metadata(
-        path="/acs/users/delete", has_required_parameters=True, has_pagination=False
+        path="/acs/users/delete",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def delete(
         self,
@@ -654,7 +641,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/delete")
 
         self.client.delete("/acs/users/delete", params=params)
@@ -662,7 +656,13 @@ class AcsUsers(AbstractAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/get", has_required_parameters=True, has_pagination=False
+        path="/acs/users/get",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -691,7 +691,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/get")
 
         res = self.client.get("/acs/users/get", params=params)
@@ -699,7 +706,7 @@ class AcsUsers(AbstractAcsUsers):
         return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/get"))
 
     @route_metadata(
-        path="/acs/users/list", has_required_parameters=False, has_pagination=True
+        path="/acs/users/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -760,7 +767,11 @@ class AcsUsers(AbstractAcsUsers):
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
         has_pagination=False,
     )
     def list_accessible_entrances(
@@ -790,7 +801,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/list_accessible_entrances"
             )
@@ -806,7 +824,7 @@ class AcsUsers(AbstractAcsUsers):
 
     @route_metadata(
         path="/acs/users/remove_from_access_group",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_from_access_group(
@@ -823,8 +841,7 @@ class AcsUsers(AbstractAcsUsers):
         :param acs_user_id: ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -834,18 +851,17 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/users/remove_from_access_group"
-            )
-
         self.client.delete("/acs/users/remove_from_access_group", params=params)
 
         return None
 
     @route_metadata(
         path="/acs/users/revoke_access_to_all_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
         has_pagination=False,
     )
     def revoke_access_to_all_entrances(
@@ -873,7 +889,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/revoke_access_to_all_entrances"
             )
@@ -883,7 +906,13 @@ class AcsUsers(AbstractAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/suspend", has_required_parameters=True, has_pagination=False
+        path="/acs/users/suspend",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def suspend(
         self,
@@ -910,7 +939,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/suspend"
             )
@@ -920,7 +956,13 @@ class AcsUsers(AbstractAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/unsuspend", has_required_parameters=True, has_pagination=False
+        path="/acs/users/unsuspend",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def unsuspend(
         self,
@@ -947,7 +989,14 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/unsuspend"
             )
@@ -957,7 +1006,19 @@ class AcsUsers(AbstractAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/update", has_required_parameters=True, has_pagination=False
+        path="/acs/users/update",
+        at_least_one_parameter_names=(
+            "access_schedule",
+            "acs_system_id",
+            "acs_user_id",
+            "email",
+            "email_address",
+            "full_name",
+            "hid_acs_system_id",
+            "phone_number",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def update(
         self,
@@ -1014,7 +1075,20 @@ class AcsUsers(AbstractAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                access_schedule,
+                acs_system_id,
+                acs_user_id,
+                email,
+                email_address,
+                full_name,
+                hid_acs_system_id,
+                phone_number,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/update")
 
         self.client.patch("/acs/users/update", json=json_payload)
@@ -1029,7 +1103,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
     @route_metadata(
         path="/acs/users/add_to_access_group",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def add_to_access_group(
@@ -1040,8 +1114,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         :param acs_access_group_id: ID of the access group to which you want to add an access system user.
 
         :param acs_user_id: ID of the access system user that you want to add to an access group.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -1049,17 +1122,12 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if acs_user_id is not None:
             json_payload["acs_user_id"] = acs_user_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /acs/users/add_to_access_group"
-            )
-
         await self.client.put("/acs/users/add_to_access_group", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/acs/users/create", has_required_parameters=True, has_pagination=False
+        path="/acs/users/create", at_least_one_parameter_names=(), has_pagination=False
     )
     async def create(
         self,
@@ -1091,9 +1159,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
         :param user_identity_id: ID of the user identity with which you want to associate the new access system user.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if acs_system_id is not None:
@@ -1113,15 +1179,18 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /acs/users/create")
-
         res = await self.client.post("/acs/users/create", json=json_payload)
 
         return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/create"))
 
     @route_metadata(
-        path="/acs/users/delete", has_required_parameters=True, has_pagination=False
+        path="/acs/users/delete",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def delete(
         self,
@@ -1148,7 +1217,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/delete")
 
         await self.client.delete("/acs/users/delete", params=params)
@@ -1156,7 +1232,13 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/get", has_required_parameters=True, has_pagination=False
+        path="/acs/users/get",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -1185,7 +1267,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/get")
 
         res = await self.client.get("/acs/users/get", params=params)
@@ -1193,7 +1282,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         return AcsUser.from_dict(unwrap(res, "acs_user", "/acs/users/get"))
 
     @route_metadata(
-        path="/acs/users/list", has_required_parameters=False, has_pagination=True
+        path="/acs/users/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -1254,7 +1343,11 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
         has_pagination=False,
     )
     async def list_accessible_entrances(
@@ -1284,7 +1377,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/list_accessible_entrances"
             )
@@ -1302,7 +1402,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
     @route_metadata(
         path="/acs/users/remove_from_access_group",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_from_access_group(
@@ -1319,8 +1419,7 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         :param acs_user_id: ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
 
         :param user_identity_id: ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_access_group_id is not None:
@@ -1330,18 +1429,17 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /acs/users/remove_from_access_group"
-            )
-
         await self.client.delete("/acs/users/remove_from_access_group", params=params)
 
         return None
 
     @route_metadata(
         path="/acs/users/revoke_access_to_all_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
         has_pagination=False,
     )
     async def revoke_access_to_all_entrances(
@@ -1369,7 +1467,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/revoke_access_to_all_entrances"
             )
@@ -1381,7 +1486,13 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/suspend", has_required_parameters=True, has_pagination=False
+        path="/acs/users/suspend",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def suspend(
         self,
@@ -1408,7 +1519,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/suspend"
             )
@@ -1418,7 +1536,13 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/unsuspend", has_required_parameters=True, has_pagination=False
+        path="/acs/users/unsuspend",
+        at_least_one_parameter_names=(
+            "acs_system_id",
+            "acs_user_id",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def unsuspend(
         self,
@@ -1445,7 +1569,14 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                acs_system_id,
+                acs_user_id,
+                user_identity_id,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /acs/users/unsuspend"
             )
@@ -1455,7 +1586,19 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         return None
 
     @route_metadata(
-        path="/acs/users/update", has_required_parameters=True, has_pagination=False
+        path="/acs/users/update",
+        at_least_one_parameter_names=(
+            "access_schedule",
+            "acs_system_id",
+            "acs_user_id",
+            "email",
+            "email_address",
+            "full_name",
+            "hid_acs_system_id",
+            "phone_number",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def update(
         self,
@@ -1512,7 +1655,20 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                access_schedule,
+                acs_system_id,
+                acs_user_id,
+                email,
+                email_address,
+                full_name,
+                hid_acs_system_id,
+                phone_number,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /acs/users/update")
 
         await self.client.patch("/acs/users/update", json=json_payload)

--- a/seam/routes/action_attempts.py
+++ b/seam/routes/action_attempts.py
@@ -27,9 +27,7 @@ class AbstractActionAttempts(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -70,9 +68,7 @@ class AbstractAsyncActionAttempts(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -104,7 +100,9 @@ class ActionAttempts(AbstractActionAttempts):
         self.defaults = defaults
 
     @route_metadata(
-        path="/action_attempts/get", has_required_parameters=True, has_pagination=False
+        path="/action_attempts/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def get(
         self,
@@ -118,18 +116,11 @@ class ActionAttempts(AbstractActionAttempts):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if action_attempt_id is not None:
             params["action_attempt_id"] = action_attempt_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /action_attempts/get"
-            )
 
         res = self.client.get("/action_attempts/get", params=params)
 
@@ -148,7 +139,9 @@ class ActionAttempts(AbstractActionAttempts):
         )
 
     @route_metadata(
-        path="/action_attempts/list", has_required_parameters=False, has_pagination=True
+        path="/action_attempts/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     def list(
         self,
@@ -194,7 +187,9 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
         self.defaults = defaults
 
     @route_metadata(
-        path="/action_attempts/get", has_required_parameters=True, has_pagination=False
+        path="/action_attempts/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -208,18 +203,11 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if action_attempt_id is not None:
             params["action_attempt_id"] = action_attempt_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /action_attempts/get"
-            )
 
         res = await self.client.get("/action_attempts/get", params=params)
 
@@ -238,7 +226,9 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
         )
 
     @route_metadata(
-        path="/action_attempts/list", has_required_parameters=False, has_pagination=True
+        path="/action_attempts/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     async def list(
         self,

--- a/seam/routes/client_sessions.py
+++ b/seam/routes/client_sessions.py
@@ -48,9 +48,7 @@ class AbstractClientSessions(abc.ABC):
     def delete(self, *, client_session_id: str) -> None:
         """Deletes a `client session <https://docs.seam.co/core-concepts/authentication/client-session-tokens>`_.
 
-        :param client_session_id: ID of the client session that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -156,9 +154,7 @@ class AbstractClientSessions(abc.ABC):
 
         Note that `deleting a client session <https://docs.seam.co/api/client_sessions/delete>`_ is a separate action.
 
-        :param client_session_id: ID of the client session that you want to revoke.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to revoke."""
         raise NotImplementedError()
 
 
@@ -202,9 +198,7 @@ class AbstractAsyncClientSessions(abc.ABC):
     async def delete(self, *, client_session_id: str) -> None:
         """Deletes a `client session <https://docs.seam.co/core-concepts/authentication/client-session-tokens>`_.
 
-        :param client_session_id: ID of the client session that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -310,9 +304,7 @@ class AbstractAsyncClientSessions(abc.ABC):
 
         Note that `deleting a client session <https://docs.seam.co/api/client_sessions/delete>`_ is a separate action.
 
-        :param client_session_id: ID of the client session that you want to revoke.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to revoke."""
         raise NotImplementedError()
 
 
@@ -323,7 +315,7 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -384,31 +376,26 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, client_session_id: str) -> None:
         """Deletes a `client session <https://docs.seam.co/core-concepts/authentication/client-session-tokens>`_.
 
-        :param client_session_id: ID of the client session that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to delete."""
         params: Dict[str, Any] = {}
 
         if client_session_id is not None:
             params["client_session_id"] = client_session_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /client_sessions/delete"
-            )
 
         self.client.delete("/client_sessions/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/client_sessions/get", has_required_parameters=False, has_pagination=False
+        path="/client_sessions/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def get(
         self,
@@ -438,7 +425,7 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/get_or_create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get_or_create(
@@ -489,7 +476,14 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/grant_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "client_session_id",
+            "connect_webview_ids",
+            "connected_account_ids",
+            "user_identifier_key",
+            "user_identity_id",
+            "user_identity_ids",
+        ),
         has_pagination=False,
     )
     def grant_access(
@@ -532,7 +526,17 @@ class ClientSessions(AbstractClientSessions):
         if user_identity_ids is not None:
             json_payload["user_identity_ids"] = user_identity_ids
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                client_session_id,
+                connect_webview_ids,
+                connected_account_ids,
+                user_identifier_key,
+                user_identity_id,
+                user_identity_ids,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /client_sessions/grant_access"
             )
@@ -543,7 +547,7 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list(
@@ -590,7 +594,7 @@ class ClientSessions(AbstractClientSessions):
 
     @route_metadata(
         path="/client_sessions/revoke",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def revoke(self, *, client_session_id: str) -> None:
@@ -598,18 +602,11 @@ class ClientSessions(AbstractClientSessions):
 
         Note that `deleting a client session <https://docs.seam.co/api/client_sessions/delete>`_ is a separate action.
 
-        :param client_session_id: ID of the client session that you want to revoke.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to revoke."""
         json_payload: Dict[str, Any] = {}
 
         if client_session_id is not None:
             json_payload["client_session_id"] = client_session_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /client_sessions/revoke"
-            )
 
         self.client.post("/client_sessions/revoke", json=json_payload)
 
@@ -623,7 +620,7 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -684,31 +681,26 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, client_session_id: str) -> None:
         """Deletes a `client session <https://docs.seam.co/core-concepts/authentication/client-session-tokens>`_.
 
-        :param client_session_id: ID of the client session that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to delete."""
         params: Dict[str, Any] = {}
 
         if client_session_id is not None:
             params["client_session_id"] = client_session_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /client_sessions/delete"
-            )
 
         await self.client.delete("/client_sessions/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/client_sessions/get", has_required_parameters=False, has_pagination=False
+        path="/client_sessions/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -738,7 +730,7 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/get_or_create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get_or_create(
@@ -791,7 +783,14 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/grant_access",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "client_session_id",
+            "connect_webview_ids",
+            "connected_account_ids",
+            "user_identifier_key",
+            "user_identity_id",
+            "user_identity_ids",
+        ),
         has_pagination=False,
     )
     async def grant_access(
@@ -834,7 +833,17 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
         if user_identity_ids is not None:
             json_payload["user_identity_ids"] = user_identity_ids
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                client_session_id,
+                connect_webview_ids,
+                connected_account_ids,
+                user_identifier_key,
+                user_identity_id,
+                user_identity_ids,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /client_sessions/grant_access"
             )
@@ -845,7 +854,7 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list(
@@ -892,7 +901,7 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
     @route_metadata(
         path="/client_sessions/revoke",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def revoke(self, *, client_session_id: str) -> None:
@@ -900,18 +909,11 @@ class AsyncClientSessions(AbstractAsyncClientSessions):
 
         Note that `deleting a client session <https://docs.seam.co/api/client_sessions/delete>`_ is a separate action.
 
-        :param client_session_id: ID of the client session that you want to revoke.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param client_session_id: ID of the client session that you want to revoke."""
         json_payload: Dict[str, Any] = {}
 
         if client_session_id is not None:
             json_payload["client_session_id"] = client_session_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /client_sessions/revoke"
-            )
 
         await self.client.post("/client_sessions/revoke", json=json_payload)
 

--- a/seam/routes/connect_webviews.py
+++ b/seam/routes/connect_webviews.py
@@ -153,9 +153,7 @@ class AbstractConnectWebviews(abc.ABC):
 
         You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
 
-        :param connect_webview_id: ID of the Connect Webview that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param connect_webview_id: ID of the Connect Webview that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -166,9 +164,7 @@ class AbstractConnectWebviews(abc.ABC):
 
         :param connect_webview_id: ID of the Connect Webview that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -345,9 +341,7 @@ class AbstractAsyncConnectWebviews(abc.ABC):
 
         You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
 
-        :param connect_webview_id: ID of the Connect Webview that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param connect_webview_id: ID of the Connect Webview that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -358,9 +352,7 @@ class AbstractAsyncConnectWebviews(abc.ABC):
 
         :param connect_webview_id: ID of the Connect Webview that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -399,7 +391,7 @@ class ConnectWebviews(AbstractConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -569,7 +561,7 @@ class ConnectWebviews(AbstractConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, connect_webview_id: str) -> None:
@@ -577,25 +569,20 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
 
-        :param connect_webview_id: ID of the Connect Webview that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param connect_webview_id: ID of the Connect Webview that you want to delete."""
         params: Dict[str, Any] = {}
 
         if connect_webview_id is not None:
             params["connect_webview_id"] = connect_webview_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connect_webviews/delete"
-            )
 
         self.client.delete("/connect_webviews/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/connect_webviews/get", has_required_parameters=True, has_pagination=False
+        path="/connect_webviews/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def get(self, *, connect_webview_id: str) -> ConnectWebview:
         """Returns a specified `Connect Webview <https://docs.seam.co/core-concepts/connect-webviews>`_.
@@ -604,18 +591,11 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         :param connect_webview_id: ID of the Connect Webview that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if connect_webview_id is not None:
             params["connect_webview_id"] = connect_webview_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connect_webviews/get"
-            )
 
         res = self.client.get("/connect_webviews/get", params=params)
 
@@ -625,7 +605,7 @@ class ConnectWebviews(AbstractConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -683,7 +663,7 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -853,7 +833,7 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, connect_webview_id: str) -> None:
@@ -861,25 +841,20 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
 
-        :param connect_webview_id: ID of the Connect Webview that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param connect_webview_id: ID of the Connect Webview that you want to delete."""
         params: Dict[str, Any] = {}
 
         if connect_webview_id is not None:
             params["connect_webview_id"] = connect_webview_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connect_webviews/delete"
-            )
 
         await self.client.delete("/connect_webviews/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/connect_webviews/get", has_required_parameters=True, has_pagination=False
+        path="/connect_webviews/get",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def get(self, *, connect_webview_id: str) -> ConnectWebview:
         """Returns a specified `Connect Webview <https://docs.seam.co/core-concepts/connect-webviews>`_.
@@ -888,18 +863,11 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         :param connect_webview_id: ID of the Connect Webview that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if connect_webview_id is not None:
             params["connect_webview_id"] = connect_webview_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connect_webviews/get"
-            )
 
         res = await self.client.get("/connect_webviews/get", params=params)
 
@@ -909,7 +877,7 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
     @route_metadata(
         path="/connect_webviews/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(

--- a/seam/routes/connected_accounts.py
+++ b/seam/routes/connected_accounts.py
@@ -30,8 +30,7 @@ class AbstractConnectedAccounts(abc.ABC):
         For example, if you delete a connected account with a device that has an access code, Seam sends a ``connected_account.deleted`` event, a ``device.deleted`` event, and an ``access_code.deleted`` event, but Seam does not remove the access code from the device.
 
         :param connected_account_id: ID of the connected account that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -85,8 +84,7 @@ class AbstractConnectedAccounts(abc.ABC):
         """Request a `connected account <https://docs.seam.co/core-concepts/connected-accounts>`_ sync attempt for the specified ``connected_account_id``.
 
         :param connected_account_id: ID of the connected account that you want to sync.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -119,8 +117,7 @@ class AbstractConnectedAccounts(abc.ABC):
         :param customer_key: The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
 
         :param display_name: Human-readable name for the connected account, shown in the dashboard. For example, ``Booking from Airbnb House 1``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -140,8 +137,7 @@ class AbstractAsyncConnectedAccounts(abc.ABC):
         For example, if you delete a connected account with a device that has an access code, Seam sends a ``connected_account.deleted`` event, a ``device.deleted`` event, and an ``access_code.deleted`` event, but Seam does not remove the access code from the device.
 
         :param connected_account_id: ID of the connected account that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -195,8 +191,7 @@ class AbstractAsyncConnectedAccounts(abc.ABC):
         """Request a `connected account <https://docs.seam.co/core-concepts/connected-accounts>`_ sync attempt for the specified ``connected_account_id``.
 
         :param connected_account_id: ID of the connected account that you want to sync.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -229,8 +224,7 @@ class AbstractAsyncConnectedAccounts(abc.ABC):
         :param customer_key: The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
 
         :param display_name: Human-readable name for the connected account, shown in the dashboard. For example, ``Booking from Airbnb House 1``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -246,7 +240,7 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, connected_account_id: str) -> None:
@@ -257,17 +251,11 @@ class ConnectedAccounts(AbstractConnectedAccounts):
         For example, if you delete a connected account with a device that has an access code, Seam sends a ``connected_account.deleted`` event, a ``device.deleted`` event, and an ``access_code.deleted`` event, but Seam does not remove the access code from the device.
 
         :param connected_account_id: ID of the connected account that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             params["connected_account_id"] = connected_account_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/delete"
-            )
 
         self.client.delete("/connected_accounts/delete", params=params)
 
@@ -275,7 +263,10 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "connected_account_id",
+            "email",
+        ),
         has_pagination=False,
     )
     def get(
@@ -297,7 +288,13 @@ class ConnectedAccounts(AbstractConnectedAccounts):
         if email is not None:
             params["email"] = email
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                connected_account_id,
+                email,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /connected_accounts/get"
             )
@@ -310,7 +307,7 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -369,24 +366,18 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/sync",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def sync(self, *, connected_account_id: str) -> None:
         """Request a `connected account <https://docs.seam.co/core-concepts/connected-accounts>`_ sync attempt for the specified ``connected_account_id``.
 
         :param connected_account_id: ID of the connected account that you want to sync.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             json_payload["connected_account_id"] = connected_account_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/sync"
-            )
 
         self.client.post("/connected_accounts/sync", json=json_payload)
 
@@ -394,7 +385,7 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -426,8 +417,7 @@ class ConnectedAccounts(AbstractConnectedAccounts):
         :param customer_key: The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
 
         :param display_name: Human-readable name for the connected account, shown in the dashboard. For example, ``Booking from Airbnb House 1``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -444,11 +434,6 @@ class ConnectedAccounts(AbstractConnectedAccounts):
             json_payload["customer_key"] = customer_key
         if display_name is not None:
             json_payload["display_name"] = display_name
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/update"
-            )
 
         self.client.patch("/connected_accounts/update", json=json_payload)
 
@@ -469,7 +454,7 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, connected_account_id: str) -> None:
@@ -480,17 +465,11 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
         For example, if you delete a connected account with a device that has an access code, Seam sends a ``connected_account.deleted`` event, a ``device.deleted`` event, and an ``access_code.deleted`` event, but Seam does not remove the access code from the device.
 
         :param connected_account_id: ID of the connected account that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             params["connected_account_id"] = connected_account_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/delete"
-            )
 
         await self.client.delete("/connected_accounts/delete", params=params)
 
@@ -498,7 +477,10 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "connected_account_id",
+            "email",
+        ),
         has_pagination=False,
     )
     async def get(
@@ -520,7 +502,13 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
         if email is not None:
             params["email"] = email
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                connected_account_id,
+                email,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /connected_accounts/get"
             )
@@ -533,7 +521,7 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(
@@ -592,24 +580,18 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/sync",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def sync(self, *, connected_account_id: str) -> None:
         """Request a `connected account <https://docs.seam.co/core-concepts/connected-accounts>`_ sync attempt for the specified ``connected_account_id``.
 
         :param connected_account_id: ID of the connected account that you want to sync.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             json_payload["connected_account_id"] = connected_account_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/sync"
-            )
 
         await self.client.post("/connected_accounts/sync", json=json_payload)
 
@@ -617,7 +599,7 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
     @route_metadata(
         path="/connected_accounts/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -649,8 +631,7 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
         :param customer_key: The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
 
         :param display_name: Human-readable name for the connected account, shown in the dashboard. For example, ``Booking from Airbnb House 1``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -667,11 +648,6 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
             json_payload["customer_key"] = customer_key
         if display_name is not None:
             json_payload["display_name"] = display_name
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/update"
-            )
 
         await self.client.patch("/connected_accounts/update", json=json_payload)
 

--- a/seam/routes/connected_accounts_simulate.py
+++ b/seam/routes/connected_accounts_simulate.py
@@ -11,8 +11,7 @@ class AbstractConnectedAccountsSimulate(abc.ABC):
         """Simulates a connected account becoming disconnected from Seam. Only applicable for `sandbox workspaces <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param connected_account_id: ID of the connected account you want to simulate as disconnected.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -23,8 +22,7 @@ class AbstractAsyncConnectedAccountsSimulate(abc.ABC):
         """Simulates a connected account becoming disconnected from Seam. Only applicable for `sandbox workspaces <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param connected_account_id: ID of the connected account you want to simulate as disconnected.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -35,24 +33,18 @@ class ConnectedAccountsSimulate(AbstractConnectedAccountsSimulate):
 
     @route_metadata(
         path="/connected_accounts/simulate/disconnect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def disconnect(self, *, connected_account_id: str) -> None:
         """Simulates a connected account becoming disconnected from Seam. Only applicable for `sandbox workspaces <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param connected_account_id: ID of the connected account you want to simulate as disconnected.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             json_payload["connected_account_id"] = connected_account_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/simulate/disconnect"
-            )
 
         self.client.post("/connected_accounts/simulate/disconnect", json=json_payload)
 
@@ -66,24 +58,18 @@ class AsyncConnectedAccountsSimulate(AbstractAsyncConnectedAccountsSimulate):
 
     @route_metadata(
         path="/connected_accounts/simulate/disconnect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def disconnect(self, *, connected_account_id: str) -> None:
         """Simulates a connected account becoming disconnected from Seam. Only applicable for `sandbox workspaces <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param connected_account_id: ID of the connected account you want to simulate as disconnected.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
             json_payload["connected_account_id"] = connected_account_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /connected_accounts/simulate/disconnect"
-            )
 
         await self.client.post(
             "/connected_accounts/simulate/disconnect", json=json_payload

--- a/seam/routes/customers.py
+++ b/seam/routes/customers.py
@@ -195,9 +195,7 @@ class AbstractCustomers(abc.ABC):
 
         :param user_identities: List of user identities.
 
-        :param users: List of users.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param users: List of users."""
         raise NotImplementedError()
 
 
@@ -390,9 +388,7 @@ class AbstractAsyncCustomers(abc.ABC):
 
         :param user_identities: List of user identities.
 
-        :param users: List of users.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param users: List of users."""
         raise NotImplementedError()
 
 
@@ -403,7 +399,7 @@ class Customers(AbstractCustomers):
 
     @route_metadata(
         path="/customers/create_portal",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create_portal(
@@ -492,7 +488,7 @@ class Customers(AbstractCustomers):
 
     @route_metadata(
         path="/customers/delete_data",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete_data(
@@ -604,7 +600,9 @@ class Customers(AbstractCustomers):
         return None
 
     @route_metadata(
-        path="/customers/push_data", has_required_parameters=True, has_pagination=False
+        path="/customers/push_data",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def push_data(
         self,
@@ -670,9 +668,7 @@ class Customers(AbstractCustomers):
 
         :param user_identities: List of user identities.
 
-        :param users: List of users.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param users: List of users."""
         json_payload: Dict[str, Any] = {}
 
         if customer_key is not None:
@@ -716,11 +712,6 @@ class Customers(AbstractCustomers):
         if users is not None:
             json_payload["users"] = users
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /customers/push_data"
-            )
-
         self.client.post("/customers/push_data", json=json_payload)
 
         return None
@@ -733,7 +724,7 @@ class AsyncCustomers(AbstractAsyncCustomers):
 
     @route_metadata(
         path="/customers/create_portal",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create_portal(
@@ -822,7 +813,7 @@ class AsyncCustomers(AbstractAsyncCustomers):
 
     @route_metadata(
         path="/customers/delete_data",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete_data(
@@ -934,7 +925,9 @@ class AsyncCustomers(AbstractAsyncCustomers):
         return None
 
     @route_metadata(
-        path="/customers/push_data", has_required_parameters=True, has_pagination=False
+        path="/customers/push_data",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def push_data(
         self,
@@ -1000,9 +993,7 @@ class AsyncCustomers(AbstractAsyncCustomers):
 
         :param user_identities: List of user identities.
 
-        :param users: List of users.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param users: List of users."""
         json_payload: Dict[str, Any] = {}
 
         if customer_key is not None:
@@ -1045,11 +1036,6 @@ class AsyncCustomers(AbstractAsyncCustomers):
             json_payload["user_identities"] = user_identities
         if users is not None:
             json_payload["users"] = users
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /customers/push_data"
-            )
 
         await self.client.post("/customers/push_data", json=json_payload)
 

--- a/seam/routes/devices.py
+++ b/seam/routes/devices.py
@@ -288,9 +288,7 @@ class AbstractDevices(abc.ABC):
     def report_provider_metadata(self, *, devices: List[Dict[str, Any]]) -> None:
         """Updates provider-specific metadata for devices.
 
-        :param devices: Array of devices with provider metadata to update
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param devices: Array of devices with provider metadata to update"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -318,9 +316,7 @@ class AbstractDevices(abc.ABC):
 
         :param name: Name for the device.
 
-        :param properties:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param properties:"""
         raise NotImplementedError()
 
 
@@ -592,9 +588,7 @@ class AbstractAsyncDevices(abc.ABC):
     async def report_provider_metadata(self, *, devices: List[Dict[str, Any]]) -> None:
         """Updates provider-specific metadata for devices.
 
-        :param devices: Array of devices with provider metadata to update
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param devices: Array of devices with provider metadata to update"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -622,9 +616,7 @@ class AbstractAsyncDevices(abc.ABC):
 
         :param name: Name for the device.
 
-        :param properties:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param properties:"""
         raise NotImplementedError()
 
 
@@ -644,7 +636,12 @@ class Devices(AbstractDevices):
         return self._unmanaged
 
     @route_metadata(
-        path="/devices/get", has_required_parameters=True, has_pagination=False
+        path="/devices/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
+        has_pagination=False,
     )
     def get(
         self, *, device_id: Optional[str] = None, name: Optional[str] = None
@@ -667,7 +664,13 @@ class Devices(AbstractDevices):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError("At least one parameter is required for /devices/get")
 
         res = self.client.get("/devices/get", params=params)
@@ -675,7 +678,7 @@ class Devices(AbstractDevices):
         return Device.from_dict(unwrap(res, "device", "/devices/get"))
 
     @route_metadata(
-        path="/devices/list", has_required_parameters=False, has_pagination=True
+        path="/devices/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -925,7 +928,7 @@ class Devices(AbstractDevices):
 
     @route_metadata(
         path="/devices/list_device_providers",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_device_providers(
@@ -969,31 +972,24 @@ class Devices(AbstractDevices):
 
     @route_metadata(
         path="/devices/report_provider_metadata",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def report_provider_metadata(self, *, devices: List[Dict[str, Any]]) -> None:
         """Updates provider-specific metadata for devices.
 
-        :param devices: Array of devices with provider metadata to update
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param devices: Array of devices with provider metadata to update"""
         json_payload: Dict[str, Any] = {}
 
         if devices is not None:
             json_payload["devices"] = devices
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/report_provider_metadata"
-            )
 
         self.client.post("/devices/report_provider_metadata", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/devices/update", has_required_parameters=True, has_pagination=False
+        path="/devices/update", at_least_one_parameter_names=(), has_pagination=False
     )
     def update(
         self,
@@ -1019,9 +1015,7 @@ class Devices(AbstractDevices):
 
         :param name: Name for the device.
 
-        :param properties:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param properties:"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1038,9 +1032,6 @@ class Devices(AbstractDevices):
             json_payload["name"] = name
         if properties is not None:
             json_payload["properties"] = properties
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /devices/update")
 
         self.client.patch("/devices/update", json=json_payload)
 
@@ -1063,7 +1054,12 @@ class AsyncDevices(AbstractAsyncDevices):
         return self._unmanaged
 
     @route_metadata(
-        path="/devices/get", has_required_parameters=True, has_pagination=False
+        path="/devices/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
+        has_pagination=False,
     )
     async def get(
         self, *, device_id: Optional[str] = None, name: Optional[str] = None
@@ -1086,7 +1082,13 @@ class AsyncDevices(AbstractAsyncDevices):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError("At least one parameter is required for /devices/get")
 
         res = await self.client.get("/devices/get", params=params)
@@ -1094,7 +1096,7 @@ class AsyncDevices(AbstractAsyncDevices):
         return Device.from_dict(unwrap(res, "device", "/devices/get"))
 
     @route_metadata(
-        path="/devices/list", has_required_parameters=False, has_pagination=True
+        path="/devices/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -1344,7 +1346,7 @@ class AsyncDevices(AbstractAsyncDevices):
 
     @route_metadata(
         path="/devices/list_device_providers",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_device_providers(
@@ -1388,31 +1390,24 @@ class AsyncDevices(AbstractAsyncDevices):
 
     @route_metadata(
         path="/devices/report_provider_metadata",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def report_provider_metadata(self, *, devices: List[Dict[str, Any]]) -> None:
         """Updates provider-specific metadata for devices.
 
-        :param devices: Array of devices with provider metadata to update
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param devices: Array of devices with provider metadata to update"""
         json_payload: Dict[str, Any] = {}
 
         if devices is not None:
             json_payload["devices"] = devices
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/report_provider_metadata"
-            )
 
         await self.client.post("/devices/report_provider_metadata", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/devices/update", has_required_parameters=True, has_pagination=False
+        path="/devices/update", at_least_one_parameter_names=(), has_pagination=False
     )
     async def update(
         self,
@@ -1438,9 +1433,7 @@ class AsyncDevices(AbstractAsyncDevices):
 
         :param name: Name for the device.
 
-        :param properties:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param properties:"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1457,9 +1450,6 @@ class AsyncDevices(AbstractAsyncDevices):
             json_payload["name"] = name
         if properties is not None:
             json_payload["properties"] = properties
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /devices/update")
 
         await self.client.patch("/devices/update", json=json_payload)
 

--- a/seam/routes/devices_simulate.py
+++ b/seam/routes/devices_simulate.py
@@ -11,8 +11,7 @@ class AbstractDevicesSimulate(abc.ABC):
         """Simulates connecting a device to Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate connecting to Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -22,9 +21,7 @@ class AbstractDevicesSimulate(abc.ABC):
         implemented for August and TTLock locks.
         This will clear the ``hub_disconnected`` error on the device.
 
-        :param device_id: ID of the device whose hub you want to reconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to reconnect."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -32,8 +29,7 @@ class AbstractDevicesSimulate(abc.ABC):
         """Simulates disconnecting a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate disconnecting from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -44,9 +40,7 @@ class AbstractDevicesSimulate(abc.ABC):
         This will set the ``hub_disconnected`` error on the device, or mark the
         IglooHome bridge offline in sandbox.
 
-        :param device_id: ID of the device whose hub you want to disconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to disconnect."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -57,9 +51,7 @@ class AbstractDevicesSimulate(abc.ABC):
 
         :param device_id:
 
-        :param is_expired:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param is_expired:"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -67,8 +59,7 @@ class AbstractDevicesSimulate(abc.ABC):
         """Simulates removing a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate removing from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -79,8 +70,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
         """Simulates connecting a device to Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate connecting to Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -90,9 +80,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
         implemented for August and TTLock locks.
         This will clear the ``hub_disconnected`` error on the device.
 
-        :param device_id: ID of the device whose hub you want to reconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to reconnect."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -100,8 +88,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
         """Simulates disconnecting a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate disconnecting from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -112,9 +99,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
         This will set the ``hub_disconnected`` error on the device, or mark the
         IglooHome bridge offline in sandbox.
 
-        :param device_id: ID of the device whose hub you want to disconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to disconnect."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -125,9 +110,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
 
         :param device_id:
 
-        :param is_expired:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param is_expired:"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -135,8 +118,7 @@ class AbstractAsyncDevicesSimulate(abc.ABC):
         """Simulates removing a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate removing from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -147,24 +129,18 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/connect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def connect(self, *, device_id: str) -> None:
         """Simulates connecting a device to Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate connecting to Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/connect"
-            )
 
         self.client.post("/devices/simulate/connect", json=json_payload)
 
@@ -172,7 +148,7 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/connect_to_hub",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def connect_to_hub(self, *, device_id: str) -> None:
@@ -181,18 +157,11 @@ class DevicesSimulate(AbstractDevicesSimulate):
         implemented for August and TTLock locks.
         This will clear the ``hub_disconnected`` error on the device.
 
-        :param device_id: ID of the device whose hub you want to reconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to reconnect."""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/connect_to_hub"
-            )
 
         self.client.post("/devices/simulate/connect_to_hub", json=json_payload)
 
@@ -200,24 +169,18 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/disconnect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def disconnect(self, *, device_id: str) -> None:
         """Simulates disconnecting a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate disconnecting from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/disconnect"
-            )
 
         self.client.post("/devices/simulate/disconnect", json=json_payload)
 
@@ -225,7 +188,7 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/disconnect_from_hub",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def disconnect_from_hub(self, *, device_id: str) -> None:
@@ -235,18 +198,11 @@ class DevicesSimulate(AbstractDevicesSimulate):
         This will set the ``hub_disconnected`` error on the device, or mark the
         IglooHome bridge offline in sandbox.
 
-        :param device_id: ID of the device whose hub you want to disconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to disconnect."""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/disconnect_from_hub"
-            )
 
         self.client.post("/devices/simulate/disconnect_from_hub", json=json_payload)
 
@@ -254,7 +210,7 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/paid_subscription",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def paid_subscription(self, *, device_id: str, is_expired: bool) -> None:
@@ -264,9 +220,7 @@ class DevicesSimulate(AbstractDevicesSimulate):
 
         :param device_id:
 
-        :param is_expired:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param is_expired:"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -274,35 +228,24 @@ class DevicesSimulate(AbstractDevicesSimulate):
         if is_expired is not None:
             json_payload["is_expired"] = is_expired
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/paid_subscription"
-            )
-
         self.client.post("/devices/simulate/paid_subscription", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/devices/simulate/remove",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove(self, *, device_id: str) -> None:
         """Simulates removing a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate removing from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/remove"
-            )
 
         self.client.post("/devices/simulate/remove", json=json_payload)
 
@@ -316,24 +259,18 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/connect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def connect(self, *, device_id: str) -> None:
         """Simulates connecting a device to Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate connecting to Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/connect"
-            )
 
         await self.client.post("/devices/simulate/connect", json=json_payload)
 
@@ -341,7 +278,7 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/connect_to_hub",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def connect_to_hub(self, *, device_id: str) -> None:
@@ -350,18 +287,11 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
         implemented for August and TTLock locks.
         This will clear the ``hub_disconnected`` error on the device.
 
-        :param device_id: ID of the device whose hub you want to reconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to reconnect."""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/connect_to_hub"
-            )
 
         await self.client.post("/devices/simulate/connect_to_hub", json=json_payload)
 
@@ -369,24 +299,18 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/disconnect",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def disconnect(self, *, device_id: str) -> None:
         """Simulates disconnecting a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate disconnecting from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/disconnect"
-            )
 
         await self.client.post("/devices/simulate/disconnect", json=json_payload)
 
@@ -394,7 +318,7 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/disconnect_from_hub",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def disconnect_from_hub(self, *, device_id: str) -> None:
@@ -404,18 +328,11 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
         This will set the ``hub_disconnected`` error on the device, or mark the
         IglooHome bridge offline in sandbox.
 
-        :param device_id: ID of the device whose hub you want to disconnect.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: ID of the device whose hub you want to disconnect."""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/disconnect_from_hub"
-            )
 
         await self.client.post(
             "/devices/simulate/disconnect_from_hub", json=json_payload
@@ -425,7 +342,7 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
     @route_metadata(
         path="/devices/simulate/paid_subscription",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def paid_subscription(self, *, device_id: str, is_expired: bool) -> None:
@@ -435,9 +352,7 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
 
         :param device_id:
 
-        :param is_expired:
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param is_expired:"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -445,35 +360,24 @@ class AsyncDevicesSimulate(AbstractAsyncDevicesSimulate):
         if is_expired is not None:
             json_payload["is_expired"] = is_expired
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/paid_subscription"
-            )
-
         await self.client.post("/devices/simulate/paid_subscription", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/devices/simulate/remove",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove(self, *, device_id: str) -> None:
         """Simulates removing a device from Seam. Only applicable for `sandbox devices <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_. See also `Testing Your App Against Device Disconnection and Removal <https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal>`_.
 
         :param device_id: ID of the device that you want to simulate removing from Seam.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/simulate/remove"
-            )
 
         await self.client.post("/devices/simulate/remove", json=json_payload)
 

--- a/seam/routes/devices_unmanaged.py
+++ b/seam/routes/devices_unmanaged.py
@@ -243,8 +243,7 @@ class AbstractDevicesUnmanaged(abc.ABC):
         :param custom_metadata: Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs, with key names up to 40 characters long that cannot contain a period (.). Set a key to ``null`` or to an empty string to remove that key from the custom metadata.
 
         :param is_managed: Indicates whether the device is managed. Set this parameter to ``true`` to convert an unmanaged device to managed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -483,8 +482,7 @@ class AbstractAsyncDevicesUnmanaged(abc.ABC):
         :param custom_metadata: Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs, with key names up to 40 characters long that cannot contain a period (.). Set a key to ``null`` or to an empty string to remove that key from the custom metadata.
 
         :param is_managed: Indicates whether the device is managed. Set this parameter to ``true`` to convert an unmanaged device to managed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -495,7 +493,10 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
         has_pagination=False,
     )
     def get(
@@ -521,7 +522,13 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /devices/unmanaged/get"
             )
@@ -534,7 +541,7 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -767,7 +774,7 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -786,8 +793,7 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
         :param custom_metadata: Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs, with key names up to 40 characters long that cannot contain a period (.). Set a key to ``null`` or to an empty string to remove that key from the custom metadata.
 
         :param is_managed: Indicates whether the device is managed. Set this parameter to ``true`` to convert an unmanaged device to managed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -796,11 +802,6 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
             json_payload["custom_metadata"] = custom_metadata
         if is_managed is not None:
             json_payload["is_managed"] = is_managed
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/unmanaged/update"
-            )
 
         self.client.patch("/devices/unmanaged/update", json=json_payload)
 
@@ -814,7 +815,10 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
         has_pagination=False,
     )
     async def get(
@@ -840,7 +844,13 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /devices/unmanaged/get"
             )
@@ -853,7 +863,7 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(
@@ -1086,7 +1096,7 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
     @route_metadata(
         path="/devices/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -1105,8 +1115,7 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
         :param custom_metadata: Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs, with key names up to 40 characters long that cannot contain a period (.). Set a key to ``null`` or to an empty string to remove that key from the custom metadata.
 
         :param is_managed: Indicates whether the device is managed. Set this parameter to ``true`` to convert an unmanaged device to managed.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1115,11 +1124,6 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
             json_payload["custom_metadata"] = custom_metadata
         if is_managed is not None:
             json_payload["is_managed"] = is_managed
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /devices/unmanaged/update"
-            )
 
         await self.client.patch("/devices/unmanaged/update", json=json_payload)
 

--- a/seam/routes/events.py
+++ b/seam/routes/events.py
@@ -725,7 +725,13 @@ class Events(AbstractEvents):
         self.defaults = defaults
 
     @route_metadata(
-        path="/events/get", has_required_parameters=True, has_pagination=False
+        path="/events/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "event_id",
+            "event_type",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -754,7 +760,14 @@ class Events(AbstractEvents):
         if event_type is not None:
             params["event_type"] = event_type
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                event_id,
+                event_type,
+            )
+        ):
             raise ValueError("At least one parameter is required for /events/get")
 
         res = self.client.get("/events/get", params=params)
@@ -762,7 +775,37 @@ class Events(AbstractEvents):
         return seam_event_from_dict(unwrap(res, "event", "/events/get"))
 
     @route_metadata(
-        path="/events/list", has_required_parameters=True, has_pagination=False
+        path="/events/list",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "access_code_ids",
+            "access_grant_id",
+            "access_grant_ids",
+            "access_method_id",
+            "access_method_ids",
+            "acs_access_group_id",
+            "acs_credential_id",
+            "acs_encoder_id",
+            "acs_entrance_id",
+            "acs_system_id",
+            "acs_system_ids",
+            "acs_user_id",
+            "between",
+            "connect_webview_id",
+            "connected_account_id",
+            "customer_key",
+            "device_id",
+            "device_ids",
+            "event_ids",
+            "event_type",
+            "event_types",
+            "since",
+            "space_id",
+            "space_ids",
+            "unstable_offset",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     def list(
         self,
@@ -1152,7 +1195,38 @@ class Events(AbstractEvents):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                access_code_ids,
+                access_grant_id,
+                access_grant_ids,
+                access_method_id,
+                access_method_ids,
+                acs_access_group_id,
+                acs_credential_id,
+                acs_encoder_id,
+                acs_entrance_id,
+                acs_system_id,
+                acs_system_ids,
+                acs_user_id,
+                between,
+                connect_webview_id,
+                connected_account_id,
+                customer_key,
+                device_id,
+                device_ids,
+                event_ids,
+                event_type,
+                event_types,
+                since,
+                space_id,
+                space_ids,
+                unstable_offset,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /events/list")
 
         res = self.client.get("/events/list", params=params)
@@ -1169,7 +1243,13 @@ class AsyncEvents(AbstractAsyncEvents):
         self.defaults = defaults
 
     @route_metadata(
-        path="/events/get", has_required_parameters=True, has_pagination=False
+        path="/events/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "event_id",
+            "event_type",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -1198,7 +1278,14 @@ class AsyncEvents(AbstractAsyncEvents):
         if event_type is not None:
             params["event_type"] = event_type
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                event_id,
+                event_type,
+            )
+        ):
             raise ValueError("At least one parameter is required for /events/get")
 
         res = await self.client.get("/events/get", params=params)
@@ -1206,7 +1293,37 @@ class AsyncEvents(AbstractAsyncEvents):
         return seam_event_from_dict(unwrap(res, "event", "/events/get"))
 
     @route_metadata(
-        path="/events/list", has_required_parameters=True, has_pagination=False
+        path="/events/list",
+        at_least_one_parameter_names=(
+            "access_code_id",
+            "access_code_ids",
+            "access_grant_id",
+            "access_grant_ids",
+            "access_method_id",
+            "access_method_ids",
+            "acs_access_group_id",
+            "acs_credential_id",
+            "acs_encoder_id",
+            "acs_entrance_id",
+            "acs_system_id",
+            "acs_system_ids",
+            "acs_user_id",
+            "between",
+            "connect_webview_id",
+            "connected_account_id",
+            "customer_key",
+            "device_id",
+            "device_ids",
+            "event_ids",
+            "event_type",
+            "event_types",
+            "since",
+            "space_id",
+            "space_ids",
+            "unstable_offset",
+            "user_identity_id",
+        ),
+        has_pagination=False,
     )
     async def list(
         self,
@@ -1596,7 +1713,38 @@ class AsyncEvents(AbstractAsyncEvents):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                access_code_id,
+                access_code_ids,
+                access_grant_id,
+                access_grant_ids,
+                access_method_id,
+                access_method_ids,
+                acs_access_group_id,
+                acs_credential_id,
+                acs_encoder_id,
+                acs_entrance_id,
+                acs_system_id,
+                acs_system_ids,
+                acs_user_id,
+                between,
+                connect_webview_id,
+                connected_account_id,
+                customer_key,
+                device_id,
+                device_ids,
+                event_ids,
+                event_type,
+                event_types,
+                since,
+                space_id,
+                space_ids,
+                unstable_offset,
+                user_identity_id,
+            )
+        ):
             raise ValueError("At least one parameter is required for /events/list")
 
         res = await self.client.get("/events/list", params=params)

--- a/seam/routes/instant_keys.py
+++ b/seam/routes/instant_keys.py
@@ -13,9 +13,7 @@ class AbstractInstantKeys(abc.ABC):
     def delete(self, *, instant_key_id: str) -> None:
         """Deletes a specified `Instant Key <https://docs.seam.co/capability-guides/instant-keys>`_.
 
-        :param instant_key_id: ID of the Instant Key that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param instant_key_id: ID of the Instant Key that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -52,9 +50,7 @@ class AbstractAsyncInstantKeys(abc.ABC):
     async def delete(self, *, instant_key_id: str) -> None:
         """Deletes a specified `Instant Key <https://docs.seam.co/capability-guides/instant-keys>`_.
 
-        :param instant_key_id: ID of the Instant Key that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param instant_key_id: ID of the Instant Key that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -91,30 +87,30 @@ class InstantKeys(AbstractInstantKeys):
         self.defaults = defaults
 
     @route_metadata(
-        path="/instant_keys/delete", has_required_parameters=True, has_pagination=False
+        path="/instant_keys/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def delete(self, *, instant_key_id: str) -> None:
         """Deletes a specified `Instant Key <https://docs.seam.co/capability-guides/instant-keys>`_.
 
-        :param instant_key_id: ID of the Instant Key that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param instant_key_id: ID of the Instant Key that you want to delete."""
         params: Dict[str, Any] = {}
 
         if instant_key_id is not None:
             params["instant_key_id"] = instant_key_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /instant_keys/delete"
-            )
 
         self.client.delete("/instant_keys/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/instant_keys/get", has_required_parameters=True, has_pagination=False
+        path="/instant_keys/get",
+        at_least_one_parameter_names=(
+            "instant_key_id",
+            "instant_key_url",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -138,7 +134,13 @@ class InstantKeys(AbstractInstantKeys):
         if instant_key_url is not None:
             params["instant_key_url"] = instant_key_url
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                instant_key_id,
+                instant_key_url,
+            )
+        ):
             raise ValueError("At least one parameter is required for /instant_keys/get")
 
         res = self.client.get("/instant_keys/get", params=params)
@@ -146,7 +148,7 @@ class InstantKeys(AbstractInstantKeys):
         return InstantKey.from_dict(unwrap(res, "instant_key", "/instant_keys/get"))
 
     @route_metadata(
-        path="/instant_keys/list", has_required_parameters=False, has_pagination=False
+        path="/instant_keys/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(self, *, user_identity_id: Optional[str] = None) -> List[InstantKey]:
         """Returns a list of all `instant keys <https://docs.seam.co/capability-guides/instant-keys>`_.
@@ -173,30 +175,30 @@ class AsyncInstantKeys(AbstractAsyncInstantKeys):
         self.defaults = defaults
 
     @route_metadata(
-        path="/instant_keys/delete", has_required_parameters=True, has_pagination=False
+        path="/instant_keys/delete",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def delete(self, *, instant_key_id: str) -> None:
         """Deletes a specified `Instant Key <https://docs.seam.co/capability-guides/instant-keys>`_.
 
-        :param instant_key_id: ID of the Instant Key that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param instant_key_id: ID of the Instant Key that you want to delete."""
         params: Dict[str, Any] = {}
 
         if instant_key_id is not None:
             params["instant_key_id"] = instant_key_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /instant_keys/delete"
-            )
 
         await self.client.delete("/instant_keys/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/instant_keys/get", has_required_parameters=True, has_pagination=False
+        path="/instant_keys/get",
+        at_least_one_parameter_names=(
+            "instant_key_id",
+            "instant_key_url",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -220,7 +222,13 @@ class AsyncInstantKeys(AbstractAsyncInstantKeys):
         if instant_key_url is not None:
             params["instant_key_url"] = instant_key_url
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                instant_key_id,
+                instant_key_url,
+            )
+        ):
             raise ValueError("At least one parameter is required for /instant_keys/get")
 
         res = await self.client.get("/instant_keys/get", params=params)
@@ -228,7 +236,7 @@ class AsyncInstantKeys(AbstractAsyncInstantKeys):
         return InstantKey.from_dict(unwrap(res, "instant_key", "/instant_keys/get"))
 
     @route_metadata(
-        path="/instant_keys/list", has_required_parameters=False, has_pagination=False
+        path="/instant_keys/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(self, *, user_identity_id: Optional[str] = None) -> List[InstantKey]:
         """Returns a list of all `instant keys <https://docs.seam.co/capability-guides/instant-keys>`_.

--- a/seam/routes/locks.py
+++ b/seam/routes/locks.py
@@ -43,9 +43,7 @@ class AbstractLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -213,9 +211,7 @@ class AbstractLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -231,9 +227,7 @@ class AbstractLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -263,9 +257,7 @@ class AbstractAsyncLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -433,9 +425,7 @@ class AbstractAsyncLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -451,9 +441,7 @@ class AbstractAsyncLocks(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -469,7 +457,7 @@ class Locks(AbstractLocks):
 
     @route_metadata(
         path="/locks/configure_auto_lock",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def configure_auto_lock(
@@ -490,9 +478,7 @@ class Locks(AbstractLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if auto_lock_enabled is not None:
@@ -501,11 +487,6 @@ class Locks(AbstractLocks):
             json_payload["device_id"] = device_id
         if auto_lock_delay_seconds is not None:
             json_payload["auto_lock_delay_seconds"] = auto_lock_delay_seconds
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/configure_auto_lock"
-            )
 
         res = self.client.post("/locks/configure_auto_lock", json=json_payload)
 
@@ -524,7 +505,12 @@ class Locks(AbstractLocks):
         )
 
     @route_metadata(
-        path="/locks/get", has_required_parameters=True, has_pagination=False
+        path="/locks/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
+        has_pagination=False,
     )
     def get(
         self, *, device_id: Optional[str] = None, name: Optional[str] = None
@@ -548,7 +534,13 @@ class Locks(AbstractLocks):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError("At least one parameter is required for /locks/get")
 
         res = self.client.get("/locks/get", params=params)
@@ -556,7 +548,7 @@ class Locks(AbstractLocks):
         return Device.from_dict(unwrap(res, "device", "/locks/get"))
 
     @route_metadata(
-        path="/locks/list", has_required_parameters=False, has_pagination=False
+        path="/locks/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(
         self,
@@ -712,7 +704,7 @@ class Locks(AbstractLocks):
         ]
 
     @route_metadata(
-        path="/locks/lock_door", has_required_parameters=True, has_pagination=False
+        path="/locks/lock_door", at_least_one_parameter_names=(), has_pagination=False
     )
     def lock_door(
         self,
@@ -726,16 +718,11 @@ class Locks(AbstractLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /locks/lock_door")
 
         res = self.client.post("/locks/lock_door", json=json_payload)
 
@@ -754,7 +741,7 @@ class Locks(AbstractLocks):
         )
 
     @route_metadata(
-        path="/locks/unlock_door", has_required_parameters=True, has_pagination=False
+        path="/locks/unlock_door", at_least_one_parameter_names=(), has_pagination=False
     )
     def unlock_door(
         self,
@@ -768,18 +755,11 @@ class Locks(AbstractLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/unlock_door"
-            )
 
         res = self.client.post("/locks/unlock_door", json=json_payload)
 
@@ -810,7 +790,7 @@ class AsyncLocks(AbstractAsyncLocks):
 
     @route_metadata(
         path="/locks/configure_auto_lock",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def configure_auto_lock(
@@ -831,9 +811,7 @@ class AsyncLocks(AbstractAsyncLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if auto_lock_enabled is not None:
@@ -842,11 +820,6 @@ class AsyncLocks(AbstractAsyncLocks):
             json_payload["device_id"] = device_id
         if auto_lock_delay_seconds is not None:
             json_payload["auto_lock_delay_seconds"] = auto_lock_delay_seconds
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/configure_auto_lock"
-            )
 
         res = await self.client.post("/locks/configure_auto_lock", json=json_payload)
 
@@ -865,7 +838,12 @@ class AsyncLocks(AbstractAsyncLocks):
         )
 
     @route_metadata(
-        path="/locks/get", has_required_parameters=True, has_pagination=False
+        path="/locks/get",
+        at_least_one_parameter_names=(
+            "device_id",
+            "name",
+        ),
+        has_pagination=False,
     )
     async def get(
         self, *, device_id: Optional[str] = None, name: Optional[str] = None
@@ -889,7 +867,13 @@ class AsyncLocks(AbstractAsyncLocks):
         if name is not None:
             params["name"] = name
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                device_id,
+                name,
+            )
+        ):
             raise ValueError("At least one parameter is required for /locks/get")
 
         res = await self.client.get("/locks/get", params=params)
@@ -897,7 +881,7 @@ class AsyncLocks(AbstractAsyncLocks):
         return Device.from_dict(unwrap(res, "device", "/locks/get"))
 
     @route_metadata(
-        path="/locks/list", has_required_parameters=False, has_pagination=False
+        path="/locks/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(
         self,
@@ -1053,7 +1037,7 @@ class AsyncLocks(AbstractAsyncLocks):
         ]
 
     @route_metadata(
-        path="/locks/lock_door", has_required_parameters=True, has_pagination=False
+        path="/locks/lock_door", at_least_one_parameter_names=(), has_pagination=False
     )
     async def lock_door(
         self,
@@ -1067,16 +1051,11 @@ class AsyncLocks(AbstractAsyncLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /locks/lock_door")
 
         res = await self.client.post("/locks/lock_door", json=json_payload)
 
@@ -1095,7 +1074,7 @@ class AsyncLocks(AbstractAsyncLocks):
         )
 
     @route_metadata(
-        path="/locks/unlock_door", has_required_parameters=True, has_pagination=False
+        path="/locks/unlock_door", at_least_one_parameter_names=(), has_pagination=False
     )
     async def unlock_door(
         self,
@@ -1109,18 +1088,11 @@ class AsyncLocks(AbstractAsyncLocks):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/unlock_door"
-            )
 
         res = await self.client.post("/locks/unlock_door", json=json_payload)
 

--- a/seam/routes/locks_simulate.py
+++ b/seam/routes/locks_simulate.py
@@ -28,9 +28,7 @@ class AbstractLocksSimulate(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -46,9 +44,7 @@ class AbstractLocksSimulate(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -70,9 +66,7 @@ class AbstractAsyncLocksSimulate(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -88,9 +82,7 @@ class AbstractAsyncLocksSimulate(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -101,7 +93,7 @@ class LocksSimulate(AbstractLocksSimulate):
 
     @route_metadata(
         path="/locks/simulate/keypad_code_entry",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def keypad_code_entry(
@@ -119,20 +111,13 @@ class LocksSimulate(AbstractLocksSimulate):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if code is not None:
             json_payload["code"] = code
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/simulate/keypad_code_entry"
-            )
 
         res = self.client.post("/locks/simulate/keypad_code_entry", json=json_payload)
 
@@ -152,7 +137,7 @@ class LocksSimulate(AbstractLocksSimulate):
 
     @route_metadata(
         path="/locks/simulate/manual_lock_via_keypad",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def manual_lock_via_keypad(
@@ -167,18 +152,11 @@ class LocksSimulate(AbstractLocksSimulate):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/simulate/manual_lock_via_keypad"
-            )
 
         res = self.client.post(
             "/locks/simulate/manual_lock_via_keypad", json=json_payload
@@ -206,7 +184,7 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
     @route_metadata(
         path="/locks/simulate/keypad_code_entry",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def keypad_code_entry(
@@ -224,20 +202,13 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if code is not None:
             json_payload["code"] = code
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/simulate/keypad_code_entry"
-            )
 
         res = await self.client.post(
             "/locks/simulate/keypad_code_entry", json=json_payload
@@ -259,7 +230,7 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
     @route_metadata(
         path="/locks/simulate/manual_lock_via_keypad",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def manual_lock_via_keypad(
@@ -274,18 +245,11 @@ class AsyncLocksSimulate(AbstractAsyncLocksSimulate):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /locks/simulate/manual_lock_via_keypad"
-            )
 
         res = await self.client.post(
             "/locks/simulate/manual_lock_via_keypad", json=json_payload

--- a/seam/routes/noise_sensors.py
+++ b/seam/routes/noise_sensors.py
@@ -126,7 +126,9 @@ class NoiseSensors(AbstractNoiseSensors):
         return self._simulate
 
     @route_metadata(
-        path="/noise_sensors/list", has_required_parameters=False, has_pagination=False
+        path="/noise_sensors/list",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def list(
         self,
@@ -198,7 +200,9 @@ class AsyncNoiseSensors(AbstractAsyncNoiseSensors):
         return self._simulate
 
     @route_metadata(
-        path="/noise_sensors/list", has_required_parameters=False, has_pagination=False
+        path="/noise_sensors/list",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def list(
         self,

--- a/seam/routes/noise_sensors_noise_thresholds.py
+++ b/seam/routes/noise_sensors_noise_thresholds.py
@@ -34,9 +34,7 @@ class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -45,9 +43,7 @@ class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param device_id: ID of the device that contains the noise threshold that you want to delete.
 
-        :param noise_threshold_id: ID of the noise threshold that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param noise_threshold_id: ID of the noise threshold that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -56,9 +52,7 @@ class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param noise_threshold_id: ID of the noise threshold that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -67,9 +61,7 @@ class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param device_id: ID of the device for which you want to list noise thresholds.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -99,8 +91,7 @@ class AbstractNoiseSensorsNoiseThresholds(abc.ABC):
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
         :param starts_daily_at: Time at which the noise threshold should become active daily.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -131,9 +122,7 @@ class AbstractAsyncNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -142,9 +131,7 @@ class AbstractAsyncNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param device_id: ID of the device that contains the noise threshold that you want to delete.
 
-        :param noise_threshold_id: ID of the noise threshold that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param noise_threshold_id: ID of the noise threshold that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -153,9 +140,7 @@ class AbstractAsyncNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param noise_threshold_id: ID of the noise threshold that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -164,9 +149,7 @@ class AbstractAsyncNoiseSensorsNoiseThresholds(abc.ABC):
 
         :param device_id: ID of the device for which you want to list noise thresholds.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -196,8 +179,7 @@ class AbstractAsyncNoiseSensorsNoiseThresholds(abc.ABC):
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
         :param starts_daily_at: Time at which the noise threshold should become active daily.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -208,7 +190,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -235,9 +217,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -253,11 +233,6 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
         if noise_threshold_nrs is not None:
             json_payload["noise_threshold_nrs"] = noise_threshold_nrs
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/create"
-            )
-
         res = self.client.post(
             "/noise_sensors/noise_thresholds/create", json=json_payload
         )
@@ -268,7 +243,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, device_id: str, noise_threshold_id: str) -> None:
@@ -276,9 +251,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         :param device_id: ID of the device that contains the noise threshold that you want to delete.
 
-        :param noise_threshold_id: ID of the noise threshold that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param noise_threshold_id: ID of the noise threshold that you want to delete."""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -286,18 +259,13 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
         if noise_threshold_id is not None:
             params["noise_threshold_id"] = noise_threshold_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/delete"
-            )
-
         self.client.delete("/noise_sensors/noise_thresholds/delete", params=params)
 
         return None
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, noise_threshold_id: str) -> NoiseThreshold:
@@ -305,18 +273,11 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         :param noise_threshold_id: ID of the noise threshold that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if noise_threshold_id is not None:
             params["noise_threshold_id"] = noise_threshold_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/get"
-            )
 
         res = self.client.get("/noise_sensors/noise_thresholds/get", params=params)
 
@@ -326,7 +287,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list(self, *, device_id: str) -> List[NoiseThreshold]:
@@ -334,18 +295,11 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
         :param device_id: ID of the device for which you want to list noise thresholds.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/list"
-            )
 
         res = self.client.get("/noise_sensors/noise_thresholds/list", params=params)
 
@@ -358,7 +312,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -387,8 +341,7 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
         :param starts_daily_at: Time at which the noise threshold should become active daily.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -406,11 +359,6 @@ class NoiseSensorsNoiseThresholds(AbstractNoiseSensorsNoiseThresholds):
         if starts_daily_at is not None:
             json_payload["starts_daily_at"] = starts_daily_at
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/update"
-            )
-
         self.client.patch("/noise_sensors/noise_thresholds/update", json=json_payload)
 
         return None
@@ -423,7 +371,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -450,9 +398,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -468,11 +414,6 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
         if noise_threshold_nrs is not None:
             json_payload["noise_threshold_nrs"] = noise_threshold_nrs
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/create"
-            )
-
         res = await self.client.post(
             "/noise_sensors/noise_thresholds/create", json=json_payload
         )
@@ -483,7 +424,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, device_id: str, noise_threshold_id: str) -> None:
@@ -491,20 +432,13 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
         :param device_id: ID of the device that contains the noise threshold that you want to delete.
 
-        :param noise_threshold_id: ID of the noise threshold that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param noise_threshold_id: ID of the noise threshold that you want to delete."""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
         if noise_threshold_id is not None:
             params["noise_threshold_id"] = noise_threshold_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/delete"
-            )
 
         await self.client.delete(
             "/noise_sensors/noise_thresholds/delete", params=params
@@ -514,7 +448,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, noise_threshold_id: str) -> NoiseThreshold:
@@ -522,18 +456,11 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
         :param noise_threshold_id: ID of the noise threshold that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if noise_threshold_id is not None:
             params["noise_threshold_id"] = noise_threshold_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/get"
-            )
 
         res = await self.client.get(
             "/noise_sensors/noise_thresholds/get", params=params
@@ -545,7 +472,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list(self, *, device_id: str) -> List[NoiseThreshold]:
@@ -553,18 +480,11 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
         :param device_id: ID of the device for which you want to list noise thresholds.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/list"
-            )
 
         res = await self.client.get(
             "/noise_sensors/noise_thresholds/list", params=params
@@ -579,7 +499,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
 
     @route_metadata(
         path="/noise_sensors/noise_thresholds/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -608,8 +528,7 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
         :param noise_threshold_nrs: Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for `Noiseaware sensors <https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors>`_.
 
         :param starts_daily_at: Time at which the noise threshold should become active daily.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -626,11 +545,6 @@ class AsyncNoiseSensorsNoiseThresholds(AbstractAsyncNoiseSensorsNoiseThresholds)
             json_payload["noise_threshold_nrs"] = noise_threshold_nrs
         if starts_daily_at is not None:
             json_payload["starts_daily_at"] = starts_daily_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/noise_thresholds/update"
-            )
 
         await self.client.patch(
             "/noise_sensors/noise_thresholds/update", json=json_payload

--- a/seam/routes/noise_sensors_simulate.py
+++ b/seam/routes/noise_sensors_simulate.py
@@ -11,8 +11,7 @@ class AbstractNoiseSensorsSimulate(abc.ABC):
         """Simulates the triggering of a `noise threshold <https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings>`_ for a `noise sensor <https://docs.seam.co/capability-guides/noise-sensors>`_ in a `sandbox workspace <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param device_id: ID of the device for which you want to simulate the triggering of a noise threshold.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -23,8 +22,7 @@ class AbstractAsyncNoiseSensorsSimulate(abc.ABC):
         """Simulates the triggering of a `noise threshold <https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings>`_ for a `noise sensor <https://docs.seam.co/capability-guides/noise-sensors>`_ in a `sandbox workspace <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param device_id: ID of the device for which you want to simulate the triggering of a noise threshold.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -35,24 +33,18 @@ class NoiseSensorsSimulate(AbstractNoiseSensorsSimulate):
 
     @route_metadata(
         path="/noise_sensors/simulate/trigger_noise_threshold",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def trigger_noise_threshold(self, *, device_id: str) -> None:
         """Simulates the triggering of a `noise threshold <https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings>`_ for a `noise sensor <https://docs.seam.co/capability-guides/noise-sensors>`_ in a `sandbox workspace <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param device_id: ID of the device for which you want to simulate the triggering of a noise threshold.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/simulate/trigger_noise_threshold"
-            )
 
         self.client.post(
             "/noise_sensors/simulate/trigger_noise_threshold", json=json_payload
@@ -68,24 +60,18 @@ class AsyncNoiseSensorsSimulate(AbstractAsyncNoiseSensorsSimulate):
 
     @route_metadata(
         path="/noise_sensors/simulate/trigger_noise_threshold",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def trigger_noise_threshold(self, *, device_id: str) -> None:
         """Simulates the triggering of a `noise threshold <https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings>`_ for a `noise sensor <https://docs.seam.co/capability-guides/noise-sensors>`_ in a `sandbox workspace <https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces>`_.
 
         :param device_id: ID of the device for which you want to simulate the triggering of a noise threshold.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /noise_sensors/simulate/trigger_noise_threshold"
-            )
 
         await self.client.post(
             "/noise_sensors/simulate/trigger_noise_threshold", json=json_payload

--- a/seam/routes/phones.py
+++ b/seam/routes/phones.py
@@ -24,9 +24,7 @@ class AbstractPhones(abc.ABC):
     def deactivate(self, *, device_id: str) -> None:
         """Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see `App User Lost Phone Process <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process>`_.
 
-        :param device_id: Device ID of the phone that you want to deactivate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: Device ID of the phone that you want to deactivate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -35,9 +33,7 @@ class AbstractPhones(abc.ABC):
 
         :param device_id: Device ID of the phone that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -68,9 +64,7 @@ class AbstractAsyncPhones(abc.ABC):
     async def deactivate(self, *, device_id: str) -> None:
         """Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see `App User Lost Phone Process <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process>`_.
 
-        :param device_id: Device ID of the phone that you want to deactivate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: Device ID of the phone that you want to deactivate."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -79,9 +73,7 @@ class AbstractAsyncPhones(abc.ABC):
 
         :param device_id: Device ID of the phone that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -112,53 +104,41 @@ class Phones(AbstractPhones):
         return self._simulate
 
     @route_metadata(
-        path="/phones/deactivate", has_required_parameters=True, has_pagination=False
+        path="/phones/deactivate", at_least_one_parameter_names=(), has_pagination=False
     )
     def deactivate(self, *, device_id: str) -> None:
         """Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see `App User Lost Phone Process <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process>`_.
 
-        :param device_id: Device ID of the phone that you want to deactivate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: Device ID of the phone that you want to deactivate."""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /phones/deactivate"
-            )
 
         self.client.delete("/phones/deactivate", params=params)
 
         return None
 
     @route_metadata(
-        path="/phones/get", has_required_parameters=True, has_pagination=False
+        path="/phones/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self, *, device_id: str) -> Phone:
         """Returns a specified `phone <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity>`_.
 
         :param device_id: Device ID of the phone that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /phones/get")
 
         res = self.client.get("/phones/get", params=params)
 
         return Phone.from_dict(unwrap(res, "phone", "/phones/get"))
 
     @route_metadata(
-        path="/phones/list", has_required_parameters=False, has_pagination=False
+        path="/phones/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(
         self,
@@ -198,53 +178,41 @@ class AsyncPhones(AbstractAsyncPhones):
         return self._simulate
 
     @route_metadata(
-        path="/phones/deactivate", has_required_parameters=True, has_pagination=False
+        path="/phones/deactivate", at_least_one_parameter_names=(), has_pagination=False
     )
     async def deactivate(self, *, device_id: str) -> None:
         """Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see `App User Lost Phone Process <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process>`_.
 
-        :param device_id: Device ID of the phone that you want to deactivate.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param device_id: Device ID of the phone that you want to deactivate."""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /phones/deactivate"
-            )
 
         await self.client.delete("/phones/deactivate", params=params)
 
         return None
 
     @route_metadata(
-        path="/phones/get", has_required_parameters=True, has_pagination=False
+        path="/phones/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self, *, device_id: str) -> Phone:
         """Returns a specified `phone <https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity>`_.
 
         :param device_id: Device ID of the phone that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /phones/get")
 
         res = await self.client.get("/phones/get", params=params)
 
         return Phone.from_dict(unwrap(res, "phone", "/phones/get"))
 
     @route_metadata(
-        path="/phones/list", has_required_parameters=False, has_pagination=False
+        path="/phones/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(
         self,

--- a/seam/routes/phones_simulate.py
+++ b/seam/routes/phones_simulate.py
@@ -27,9 +27,7 @@ class AbstractPhonesSimulate(abc.ABC):
 
         :param phone_metadata: Metadata that you want to associate with the simulated phone.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -54,9 +52,7 @@ class AbstractAsyncPhonesSimulate(abc.ABC):
 
         :param phone_metadata: Metadata that you want to associate with the simulated phone.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -67,7 +63,7 @@ class PhonesSimulate(AbstractPhonesSimulate):
 
     @route_metadata(
         path="/phones/simulate/create_sandbox_phone",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create_sandbox_phone(
@@ -88,9 +84,7 @@ class PhonesSimulate(AbstractPhonesSimulate):
 
         :param phone_metadata: Metadata that you want to associate with the simulated phone.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -101,11 +95,6 @@ class PhonesSimulate(AbstractPhonesSimulate):
             json_payload["custom_sdk_installation_id"] = custom_sdk_installation_id
         if phone_metadata is not None:
             json_payload["phone_metadata"] = phone_metadata
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /phones/simulate/create_sandbox_phone"
-            )
 
         res = self.client.post(
             "/phones/simulate/create_sandbox_phone", json=json_payload
@@ -123,7 +112,7 @@ class AsyncPhonesSimulate(AbstractAsyncPhonesSimulate):
 
     @route_metadata(
         path="/phones/simulate/create_sandbox_phone",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create_sandbox_phone(
@@ -144,9 +133,7 @@ class AsyncPhonesSimulate(AbstractAsyncPhonesSimulate):
 
         :param phone_metadata: Metadata that you want to associate with the simulated phone.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -157,11 +144,6 @@ class AsyncPhonesSimulate(AbstractAsyncPhonesSimulate):
             json_payload["custom_sdk_installation_id"] = custom_sdk_installation_id
         if phone_metadata is not None:
             json_payload["phone_metadata"] = phone_metadata
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /phones/simulate/create_sandbox_phone"
-            )
 
         res = await self.client.post(
             "/phones/simulate/create_sandbox_phone", json=json_payload

--- a/seam/routes/spaces.py
+++ b/seam/routes/spaces.py
@@ -16,9 +16,7 @@ class AbstractSpaces(abc.ABC):
 
         :param acs_entrance_ids: IDs of the entrances that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add entrances."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -30,8 +28,7 @@ class AbstractSpaces(abc.ABC):
         :param connected_account_id: ID of the connected account that you want to add to the space.
 
         :param space_id: ID of the space to which you want to add the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -40,9 +37,7 @@ class AbstractSpaces(abc.ABC):
 
         :param device_ids: IDs of the devices that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add devices."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -73,18 +68,14 @@ class AbstractSpaces(abc.ABC):
 
         :param space_key: Unique key for the space within the workspace.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def delete(self, *, space_id: str) -> None:
         """Deletes a space.
 
-        :param space_id: ID of the space that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -181,9 +172,7 @@ class AbstractSpaces(abc.ABC):
 
         :param acs_entrance_ids: IDs of the entrances that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove entrances."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -195,8 +184,7 @@ class AbstractSpaces(abc.ABC):
         :param connected_account_id: ID of the connected account that you want to remove from the space.
 
         :param space_id: ID of the space from which you want to remove the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -205,9 +193,7 @@ class AbstractSpaces(abc.ABC):
 
         :param device_ids: IDs of the devices that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove devices."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -249,9 +235,7 @@ class AbstractAsyncSpaces(abc.ABC):
 
         :param acs_entrance_ids: IDs of the entrances that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add entrances."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -263,8 +247,7 @@ class AbstractAsyncSpaces(abc.ABC):
         :param connected_account_id: ID of the connected account that you want to add to the space.
 
         :param space_id: ID of the space to which you want to add the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -273,9 +256,7 @@ class AbstractAsyncSpaces(abc.ABC):
 
         :param device_ids: IDs of the devices that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add devices."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -306,18 +287,14 @@ class AbstractAsyncSpaces(abc.ABC):
 
         :param space_key: Unique key for the space within the workspace.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def delete(self, *, space_id: str) -> None:
         """Deletes a space.
 
-        :param space_id: ID of the space that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -414,9 +391,7 @@ class AbstractAsyncSpaces(abc.ABC):
 
         :param acs_entrance_ids: IDs of the entrances that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove entrances."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -428,8 +403,7 @@ class AbstractAsyncSpaces(abc.ABC):
         :param connected_account_id: ID of the connected account that you want to remove from the space.
 
         :param space_id: ID of the space from which you want to remove the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -438,9 +412,7 @@ class AbstractAsyncSpaces(abc.ABC):
 
         :param device_ids: IDs of the devices that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove devices."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -479,7 +451,7 @@ class Spaces(AbstractSpaces):
 
     @route_metadata(
         path="/spaces/add_acs_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def add_acs_entrances(self, *, acs_entrance_ids: List[str], space_id: str) -> None:
@@ -487,9 +459,7 @@ class Spaces(AbstractSpaces):
 
         :param acs_entrance_ids: IDs of the entrances that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add entrances."""
         json_payload: Dict[str, Any] = {}
 
         if acs_entrance_ids is not None:
@@ -497,18 +467,13 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_acs_entrances"
-            )
-
         self.client.put("/spaces/add_acs_entrances", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/spaces/add_connected_account",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def add_connected_account(
@@ -519,8 +484,7 @@ class Spaces(AbstractSpaces):
         :param connected_account_id: ID of the connected account that you want to add to the space.
 
         :param space_id: ID of the space to which you want to add the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -528,26 +492,21 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_connected_account"
-            )
-
         self.client.put("/spaces/add_connected_account", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/spaces/add_devices", has_required_parameters=True, has_pagination=False
+        path="/spaces/add_devices",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     def add_devices(self, *, device_ids: List[str], space_id: str) -> None:
         """Adds devices to a specific space.
 
         :param device_ids: IDs of the devices that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add devices."""
         json_payload: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -555,17 +514,12 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_devices"
-            )
-
         self.client.put("/spaces/add_devices", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/spaces/create", has_required_parameters=True, has_pagination=False
+        path="/spaces/create", at_least_one_parameter_names=(), has_pagination=False
     )
     def create(
         self,
@@ -594,9 +548,7 @@ class Spaces(AbstractSpaces):
 
         :param space_key: Unique key for the space within the workspace.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -614,36 +566,33 @@ class Spaces(AbstractSpaces):
         if space_key is not None:
             json_payload["space_key"] = space_key
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /spaces/create")
-
         res = self.client.post("/spaces/create", json=json_payload)
 
         return Space.from_dict(unwrap(res, "space", "/spaces/create"))
 
     @route_metadata(
-        path="/spaces/delete", has_required_parameters=True, has_pagination=False
+        path="/spaces/delete", at_least_one_parameter_names=(), has_pagination=False
     )
     def delete(self, *, space_id: str) -> None:
         """Deletes a space.
 
-        :param space_id: ID of the space that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space that you want to delete."""
         params: Dict[str, Any] = {}
 
         if space_id is not None:
             params["space_id"] = space_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /spaces/delete")
 
         self.client.delete("/spaces/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/spaces/get", has_required_parameters=True, has_pagination=False
+        path="/spaces/get",
+        at_least_one_parameter_names=(
+            "space_id",
+            "space_key",
+        ),
+        has_pagination=False,
     )
     def get(
         self, *, space_id: Optional[str] = None, space_key: Optional[str] = None
@@ -664,7 +613,13 @@ class Spaces(AbstractSpaces):
         if space_key is not None:
             params["space_key"] = space_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                space_id,
+                space_key,
+            )
+        ):
             raise ValueError("At least one parameter is required for /spaces/get")
 
         res = self.client.get("/spaces/get", params=params)
@@ -672,7 +627,14 @@ class Spaces(AbstractSpaces):
         return Space.from_dict(unwrap(res, "space", "/spaces/get"))
 
     @route_metadata(
-        path="/spaces/get_related", has_required_parameters=True, has_pagination=False
+        path="/spaces/get_related",
+        at_least_one_parameter_names=(
+            "exclude",
+            "include",
+            "space_ids",
+            "space_keys",
+        ),
+        has_pagination=False,
     )
     def get_related(
         self,
@@ -728,7 +690,15 @@ class Spaces(AbstractSpaces):
         if space_keys is not None:
             params["space_keys"] = space_keys
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                exclude,
+                include,
+                space_ids,
+                space_keys,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /spaces/get_related"
             )
@@ -738,7 +708,7 @@ class Spaces(AbstractSpaces):
         return Batch.from_dict(unwrap(res, "batch", "/spaces/get_related"))
 
     @route_metadata(
-        path="/spaces/list", has_required_parameters=False, has_pagination=True
+        path="/spaces/list", at_least_one_parameter_names=(), has_pagination=True
     )
     def list(
         self,
@@ -783,7 +753,7 @@ class Spaces(AbstractSpaces):
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_acs_entrances(
@@ -793,9 +763,7 @@ class Spaces(AbstractSpaces):
 
         :param acs_entrance_ids: IDs of the entrances that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove entrances."""
         params: Dict[str, Any] = {}
 
         if acs_entrance_ids is not None:
@@ -803,18 +771,13 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_acs_entrances"
-            )
-
         self.client.delete("/spaces/remove_acs_entrances", params=params)
 
         return None
 
     @route_metadata(
         path="/spaces/remove_connected_account",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_connected_account(
@@ -825,8 +788,7 @@ class Spaces(AbstractSpaces):
         :param connected_account_id: ID of the connected account that you want to remove from the space.
 
         :param space_id: ID of the space from which you want to remove the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -834,18 +796,13 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_connected_account"
-            )
-
         self.client.delete("/spaces/remove_connected_account", params=params)
 
         return None
 
     @route_metadata(
         path="/spaces/remove_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_devices(self, *, device_ids: List[str], space_id: str) -> None:
@@ -853,9 +810,7 @@ class Spaces(AbstractSpaces):
 
         :param device_ids: IDs of the devices that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove devices."""
         params: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -863,17 +818,12 @@ class Spaces(AbstractSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_devices"
-            )
-
         self.client.delete("/spaces/remove_devices", params=params)
 
         return None
 
     @route_metadata(
-        path="/spaces/update", has_required_parameters=False, has_pagination=False
+        path="/spaces/update", at_least_one_parameter_names=(), has_pagination=False
     )
     def update(
         self,
@@ -927,7 +877,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
     @route_metadata(
         path="/spaces/add_acs_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def add_acs_entrances(
@@ -937,9 +887,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         :param acs_entrance_ids: IDs of the entrances that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add entrances."""
         json_payload: Dict[str, Any] = {}
 
         if acs_entrance_ids is not None:
@@ -947,18 +895,13 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_acs_entrances"
-            )
-
         await self.client.put("/spaces/add_acs_entrances", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/spaces/add_connected_account",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def add_connected_account(
@@ -969,8 +912,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
         :param connected_account_id: ID of the connected account that you want to add to the space.
 
         :param space_id: ID of the space to which you want to add the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -978,26 +920,21 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_connected_account"
-            )
-
         await self.client.put("/spaces/add_connected_account", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/spaces/add_devices", has_required_parameters=True, has_pagination=False
+        path="/spaces/add_devices",
+        at_least_one_parameter_names=(),
+        has_pagination=False,
     )
     async def add_devices(self, *, device_ids: List[str], space_id: str) -> None:
         """Adds devices to a specific space.
 
         :param device_ids: IDs of the devices that you want to add to the space.
 
-        :param space_id: ID of the space to which you want to add devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space to which you want to add devices."""
         json_payload: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -1005,17 +942,12 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             json_payload["space_id"] = space_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /spaces/add_devices"
-            )
-
         await self.client.put("/spaces/add_devices", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/spaces/create", has_required_parameters=True, has_pagination=False
+        path="/spaces/create", at_least_one_parameter_names=(), has_pagination=False
     )
     async def create(
         self,
@@ -1044,9 +976,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         :param space_key: Unique key for the space within the workspace.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -1064,36 +994,33 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_key is not None:
             json_payload["space_key"] = space_key
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /spaces/create")
-
         res = await self.client.post("/spaces/create", json=json_payload)
 
         return Space.from_dict(unwrap(res, "space", "/spaces/create"))
 
     @route_metadata(
-        path="/spaces/delete", has_required_parameters=True, has_pagination=False
+        path="/spaces/delete", at_least_one_parameter_names=(), has_pagination=False
     )
     async def delete(self, *, space_id: str) -> None:
         """Deletes a space.
 
-        :param space_id: ID of the space that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space that you want to delete."""
         params: Dict[str, Any] = {}
 
         if space_id is not None:
             params["space_id"] = space_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /spaces/delete")
 
         await self.client.delete("/spaces/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/spaces/get", has_required_parameters=True, has_pagination=False
+        path="/spaces/get",
+        at_least_one_parameter_names=(
+            "space_id",
+            "space_key",
+        ),
+        has_pagination=False,
     )
     async def get(
         self, *, space_id: Optional[str] = None, space_key: Optional[str] = None
@@ -1114,7 +1041,13 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_key is not None:
             params["space_key"] = space_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                space_id,
+                space_key,
+            )
+        ):
             raise ValueError("At least one parameter is required for /spaces/get")
 
         res = await self.client.get("/spaces/get", params=params)
@@ -1122,7 +1055,14 @@ class AsyncSpaces(AbstractAsyncSpaces):
         return Space.from_dict(unwrap(res, "space", "/spaces/get"))
 
     @route_metadata(
-        path="/spaces/get_related", has_required_parameters=True, has_pagination=False
+        path="/spaces/get_related",
+        at_least_one_parameter_names=(
+            "exclude",
+            "include",
+            "space_ids",
+            "space_keys",
+        ),
+        has_pagination=False,
     )
     async def get_related(
         self,
@@ -1178,7 +1118,15 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_keys is not None:
             params["space_keys"] = space_keys
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                exclude,
+                include,
+                space_ids,
+                space_keys,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /spaces/get_related"
             )
@@ -1188,7 +1136,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
         return Batch.from_dict(unwrap(res, "batch", "/spaces/get_related"))
 
     @route_metadata(
-        path="/spaces/list", has_required_parameters=False, has_pagination=True
+        path="/spaces/list", at_least_one_parameter_names=(), has_pagination=True
     )
     async def list(
         self,
@@ -1233,7 +1181,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_acs_entrances(
@@ -1243,9 +1191,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         :param acs_entrance_ids: IDs of the entrances that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove entrances.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove entrances."""
         params: Dict[str, Any] = {}
 
         if acs_entrance_ids is not None:
@@ -1253,18 +1199,13 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_acs_entrances"
-            )
-
         await self.client.delete("/spaces/remove_acs_entrances", params=params)
 
         return None
 
     @route_metadata(
         path="/spaces/remove_connected_account",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_connected_account(
@@ -1275,8 +1216,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
         :param connected_account_id: ID of the connected account that you want to remove from the space.
 
         :param space_id: ID of the space from which you want to remove the connected account.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if connected_account_id is not None:
@@ -1284,18 +1224,13 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_connected_account"
-            )
-
         await self.client.delete("/spaces/remove_connected_account", params=params)
 
         return None
 
     @route_metadata(
         path="/spaces/remove_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_devices(self, *, device_ids: List[str], space_id: str) -> None:
@@ -1303,9 +1238,7 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         :param device_ids: IDs of the devices that you want to remove from the space.
 
-        :param space_id: ID of the space from which you want to remove devices.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param space_id: ID of the space from which you want to remove devices."""
         params: Dict[str, Any] = {}
 
         if device_ids is not None:
@@ -1313,17 +1246,12 @@ class AsyncSpaces(AbstractAsyncSpaces):
         if space_id is not None:
             params["space_id"] = space_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /spaces/remove_devices"
-            )
-
         await self.client.delete("/spaces/remove_devices", params=params)
 
         return None
 
     @route_metadata(
-        path="/spaces/update", has_required_parameters=False, has_pagination=False
+        path="/spaces/update", at_least_one_parameter_names=(), has_pagination=False
     )
     async def update(
         self,

--- a/seam/routes/thermostats.py
+++ b/seam/routes/thermostats.py
@@ -63,9 +63,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -87,9 +85,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -138,8 +134,7 @@ class AbstractThermostats(abc.ABC):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat or using the API can change the thermostat's settings.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -149,8 +144,7 @@ class AbstractThermostats(abc.ABC):
         :param climate_preset_key: Climate preset key of the climate preset that you want to delete.
 
         :param device_id: ID of the thermostat device for which you want to delete a climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -172,9 +166,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -202,9 +194,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -272,9 +262,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -286,8 +274,7 @@ class AbstractThermostats(abc.ABC):
         :param climate_preset_key: Climate preset key of the climate preset that you want to set as the fallback climate preset.
 
         :param device_id: ID of the thermostat device for which you want to set the fallback climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -309,9 +296,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -342,9 +327,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -368,8 +351,7 @@ class AbstractThermostats(abc.ABC):
         :param upper_limit_celsius: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
 
         :param upper_limit_fahrenheit: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -418,8 +400,7 @@ class AbstractThermostats(abc.ABC):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat can change the thermostat's settings. See `Specifying Manual Override Permissions <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions>`_.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -456,9 +437,7 @@ class AbstractThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -495,9 +474,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -519,9 +496,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -570,8 +545,7 @@ class AbstractAsyncThermostats(abc.ABC):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat or using the API can change the thermostat's settings.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -583,8 +557,7 @@ class AbstractAsyncThermostats(abc.ABC):
         :param climate_preset_key: Climate preset key of the climate preset that you want to delete.
 
         :param device_id: ID of the thermostat device for which you want to delete a climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -606,9 +579,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -636,9 +607,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -706,9 +675,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -720,8 +687,7 @@ class AbstractAsyncThermostats(abc.ABC):
         :param climate_preset_key: Climate preset key of the climate preset that you want to set as the fallback climate preset.
 
         :param device_id: ID of the thermostat device for which you want to set the fallback climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -743,9 +709,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -776,9 +740,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -802,8 +764,7 @@ class AbstractAsyncThermostats(abc.ABC):
         :param upper_limit_celsius: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
 
         :param upper_limit_fahrenheit: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -852,8 +813,7 @@ class AbstractAsyncThermostats(abc.ABC):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat can change the thermostat's settings. See `Specifying Manual Override Permissions <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions>`_.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -890,9 +850,7 @@ class AbstractAsyncThermostats(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -920,7 +878,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/activate_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def activate_climate_preset(
@@ -938,20 +896,13 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
             json_payload["climate_preset_key"] = climate_preset_key
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/activate_climate_preset"
-            )
 
         res = self.client.post(
             "/thermostats/activate_climate_preset", json=json_payload
@@ -972,7 +923,7 @@ class Thermostats(AbstractThermostats):
         )
 
     @route_metadata(
-        path="/thermostats/cool", has_required_parameters=True, has_pagination=False
+        path="/thermostats/cool", at_least_one_parameter_names=(), has_pagination=False
     )
     def cool(
         self,
@@ -992,9 +943,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1003,9 +952,6 @@ class Thermostats(AbstractThermostats):
             json_payload["cooling_set_point_celsius"] = cooling_set_point_celsius
         if cooling_set_point_fahrenheit is not None:
             json_payload["cooling_set_point_fahrenheit"] = cooling_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/cool")
 
         res = self.client.post("/thermostats/cool", json=json_payload)
 
@@ -1025,7 +971,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/create_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create_climate_preset(
@@ -1073,8 +1019,7 @@ class Thermostats(AbstractThermostats):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat or using the API can change the thermostat's settings.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1102,18 +1047,13 @@ class Thermostats(AbstractThermostats):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/create_climate_preset"
-            )
-
         self.client.post("/thermostats/create_climate_preset", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/delete_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete_climate_preset(self, *, climate_preset_key: str, device_id: str) -> None:
@@ -1122,8 +1062,7 @@ class Thermostats(AbstractThermostats):
         :param climate_preset_key: Climate preset key of the climate preset that you want to delete.
 
         :param device_id: ID of the thermostat device for which you want to delete a climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1131,17 +1070,12 @@ class Thermostats(AbstractThermostats):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/delete_climate_preset"
-            )
-
         self.client.delete("/thermostats/delete_climate_preset", params=params)
 
         return None
 
     @route_metadata(
-        path="/thermostats/heat", has_required_parameters=True, has_pagination=False
+        path="/thermostats/heat", at_least_one_parameter_names=(), has_pagination=False
     )
     def heat(
         self,
@@ -1161,9 +1095,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1172,9 +1104,6 @@ class Thermostats(AbstractThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/heat")
 
         res = self.client.post("/thermostats/heat", json=json_payload)
 
@@ -1194,7 +1123,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/heat_cool",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def heat_cool(
@@ -1221,9 +1150,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1236,11 +1163,6 @@ class Thermostats(AbstractThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/heat_cool"
-            )
 
         res = self.client.post("/thermostats/heat_cool", json=json_payload)
 
@@ -1259,7 +1181,7 @@ class Thermostats(AbstractThermostats):
         )
 
     @route_metadata(
-        path="/thermostats/list", has_required_parameters=False, has_pagination=False
+        path="/thermostats/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(
         self,
@@ -1333,7 +1255,7 @@ class Thermostats(AbstractThermostats):
         ]
 
     @route_metadata(
-        path="/thermostats/off", has_required_parameters=True, has_pagination=False
+        path="/thermostats/off", at_least_one_parameter_names=(), has_pagination=False
     )
     def off(
         self,
@@ -1347,16 +1269,11 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/off")
 
         res = self.client.post("/thermostats/off", json=json_payload)
 
@@ -1376,7 +1293,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/set_fallback_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def set_fallback_climate_preset(
@@ -1387,8 +1304,7 @@ class Thermostats(AbstractThermostats):
         :param climate_preset_key: Climate preset key of the climate preset that you want to set as the fallback climate preset.
 
         :param device_id: ID of the thermostat device for which you want to set the fallback climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1396,18 +1312,13 @@ class Thermostats(AbstractThermostats):
         if device_id is not None:
             json_payload["device_id"] = device_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_fallback_climate_preset"
-            )
-
         self.client.post("/thermostats/set_fallback_climate_preset", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/set_fan_mode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def set_fan_mode(
@@ -1428,9 +1339,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1439,11 +1348,6 @@ class Thermostats(AbstractThermostats):
             json_payload["fan_mode"] = fan_mode
         if fan_mode_setting is not None:
             json_payload["fan_mode_setting"] = fan_mode_setting
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_fan_mode"
-            )
 
         res = self.client.post("/thermostats/set_fan_mode", json=json_payload)
 
@@ -1463,7 +1367,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/set_hvac_mode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def set_hvac_mode(
@@ -1493,9 +1397,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1510,11 +1412,6 @@ class Thermostats(AbstractThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_hvac_mode"
-            )
 
         res = self.client.post("/thermostats/set_hvac_mode", json=json_payload)
 
@@ -1534,7 +1431,7 @@ class Thermostats(AbstractThermostats):
 
     @route_metadata(
         path="/thermostats/set_temperature_threshold",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def set_temperature_threshold(
@@ -1557,8 +1454,7 @@ class Thermostats(AbstractThermostats):
         :param upper_limit_celsius: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
 
         :param upper_limit_fahrenheit: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1572,18 +1468,13 @@ class Thermostats(AbstractThermostats):
         if upper_limit_fahrenheit is not None:
             json_payload["upper_limit_fahrenheit"] = upper_limit_fahrenheit
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_temperature_threshold"
-            )
-
         self.client.patch("/thermostats/set_temperature_threshold", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/update_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update_climate_preset(
@@ -1631,8 +1522,7 @@ class Thermostats(AbstractThermostats):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat can change the thermostat's settings. See `Specifying Manual Override Permissions <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions>`_.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1660,18 +1550,13 @@ class Thermostats(AbstractThermostats):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/update_climate_preset"
-            )
-
         self.client.patch("/thermostats/update_climate_preset", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/update_weekly_program",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update_weekly_program(
@@ -1707,9 +1592,7 @@ class Thermostats(AbstractThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1728,11 +1611,6 @@ class Thermostats(AbstractThermostats):
             json_payload["tuesday_program_id"] = tuesday_program_id
         if wednesday_program_id is not None:
             json_payload["wednesday_program_id"] = wednesday_program_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/update_weekly_program"
-            )
 
         res = self.client.post("/thermostats/update_weekly_program", json=json_payload)
 
@@ -1775,7 +1653,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/activate_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def activate_climate_preset(
@@ -1793,20 +1671,13 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
             json_payload["climate_preset_key"] = climate_preset_key
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/activate_climate_preset"
-            )
 
         res = await self.client.post(
             "/thermostats/activate_climate_preset", json=json_payload
@@ -1827,7 +1698,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         )
 
     @route_metadata(
-        path="/thermostats/cool", has_required_parameters=True, has_pagination=False
+        path="/thermostats/cool", at_least_one_parameter_names=(), has_pagination=False
     )
     async def cool(
         self,
@@ -1847,9 +1718,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1858,9 +1727,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["cooling_set_point_celsius"] = cooling_set_point_celsius
         if cooling_set_point_fahrenheit is not None:
             json_payload["cooling_set_point_fahrenheit"] = cooling_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/cool")
 
         res = await self.client.post("/thermostats/cool", json=json_payload)
 
@@ -1880,7 +1746,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/create_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create_climate_preset(
@@ -1928,8 +1794,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat or using the API can change the thermostat's settings.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1957,18 +1822,13 @@ class AsyncThermostats(AbstractAsyncThermostats):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/create_climate_preset"
-            )
-
         await self.client.post("/thermostats/create_climate_preset", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/delete_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete_climate_preset(
@@ -1979,8 +1839,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         :param climate_preset_key: Climate preset key of the climate preset that you want to delete.
 
         :param device_id: ID of the thermostat device for which you want to delete a climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -1988,17 +1847,12 @@ class AsyncThermostats(AbstractAsyncThermostats):
         if device_id is not None:
             params["device_id"] = device_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/delete_climate_preset"
-            )
-
         await self.client.delete("/thermostats/delete_climate_preset", params=params)
 
         return None
 
     @route_metadata(
-        path="/thermostats/heat", has_required_parameters=True, has_pagination=False
+        path="/thermostats/heat", at_least_one_parameter_names=(), has_pagination=False
     )
     async def heat(
         self,
@@ -2018,9 +1872,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2029,9 +1881,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/heat")
 
         res = await self.client.post("/thermostats/heat", json=json_payload)
 
@@ -2051,7 +1900,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/heat_cool",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def heat_cool(
@@ -2078,9 +1927,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2093,11 +1940,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/heat_cool"
-            )
 
         res = await self.client.post("/thermostats/heat_cool", json=json_payload)
 
@@ -2116,7 +1958,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         )
 
     @route_metadata(
-        path="/thermostats/list", has_required_parameters=False, has_pagination=False
+        path="/thermostats/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(
         self,
@@ -2190,7 +2032,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         ]
 
     @route_metadata(
-        path="/thermostats/off", has_required_parameters=True, has_pagination=False
+        path="/thermostats/off", at_least_one_parameter_names=(), has_pagination=False
     )
     async def off(
         self,
@@ -2204,16 +2046,11 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /thermostats/off")
 
         res = await self.client.post("/thermostats/off", json=json_payload)
 
@@ -2233,7 +2070,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/set_fallback_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def set_fallback_climate_preset(
@@ -2244,19 +2081,13 @@ class AsyncThermostats(AbstractAsyncThermostats):
         :param climate_preset_key: Climate preset key of the climate preset that you want to set as the fallback climate preset.
 
         :param device_id: ID of the thermostat device for which you want to set the fallback climate preset.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
             json_payload["climate_preset_key"] = climate_preset_key
         if device_id is not None:
             json_payload["device_id"] = device_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_fallback_climate_preset"
-            )
 
         await self.client.post(
             "/thermostats/set_fallback_climate_preset", json=json_payload
@@ -2266,7 +2097,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/set_fan_mode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def set_fan_mode(
@@ -2287,9 +2118,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2298,11 +2127,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["fan_mode"] = fan_mode
         if fan_mode_setting is not None:
             json_payload["fan_mode_setting"] = fan_mode_setting
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_fan_mode"
-            )
 
         res = await self.client.post("/thermostats/set_fan_mode", json=json_payload)
 
@@ -2322,7 +2146,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/set_hvac_mode",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def set_hvac_mode(
@@ -2352,9 +2176,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2369,11 +2191,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["heating_set_point_celsius"] = heating_set_point_celsius
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_hvac_mode"
-            )
 
         res = await self.client.post("/thermostats/set_hvac_mode", json=json_payload)
 
@@ -2393,7 +2210,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/set_temperature_threshold",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def set_temperature_threshold(
@@ -2416,8 +2233,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         :param upper_limit_celsius: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
 
         :param upper_limit_fahrenheit: Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either ``upper_limit`` but not both.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2431,11 +2247,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
         if upper_limit_fahrenheit is not None:
             json_payload["upper_limit_fahrenheit"] = upper_limit_fahrenheit
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/set_temperature_threshold"
-            )
-
         await self.client.patch(
             "/thermostats/set_temperature_threshold", json=json_payload
         )
@@ -2444,7 +2255,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
     @route_metadata(
         path="/thermostats/update_climate_preset",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update_climate_preset(
@@ -2492,8 +2303,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
         :param manual_override_allowed: Deprecated: Use 'thermostat_schedule.is_override_allowed' Indicates whether a person at the thermostat can change the thermostat's settings. See `Specifying Manual Override Permissions <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions>`_.
 
         :param name: User-friendly name to identify the `climate preset <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets>`_.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -2521,18 +2331,13 @@ class AsyncThermostats(AbstractAsyncThermostats):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/update_climate_preset"
-            )
-
         await self.client.patch("/thermostats/update_climate_preset", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/update_weekly_program",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update_weekly_program(
@@ -2568,9 +2373,7 @@ class AsyncThermostats(AbstractAsyncThermostats):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -2589,11 +2392,6 @@ class AsyncThermostats(AbstractAsyncThermostats):
             json_payload["tuesday_program_id"] = tuesday_program_id
         if wednesday_program_id is not None:
             json_payload["wednesday_program_id"] = wednesday_program_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/update_weekly_program"
-            )
 
         res = await self.client.post(
             "/thermostats/update_weekly_program", json=json_payload

--- a/seam/routes/thermostats_daily_programs.py
+++ b/seam/routes/thermostats_daily_programs.py
@@ -24,9 +24,7 @@ class AbstractThermostatsDailyPrograms(abc.ABC):
 
         :param periods: Array of thermostat daily program periods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -34,8 +32,7 @@ class AbstractThermostatsDailyPrograms(abc.ABC):
         """Deletes a thermostat daily program.
 
         :param thermostat_daily_program_id: ID of the thermostat daily program that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -57,9 +54,7 @@ class AbstractThermostatsDailyPrograms(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -77,9 +72,7 @@ class AbstractAsyncThermostatsDailyPrograms(abc.ABC):
 
         :param periods: Array of thermostat daily program periods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -87,8 +80,7 @@ class AbstractAsyncThermostatsDailyPrograms(abc.ABC):
         """Deletes a thermostat daily program.
 
         :param thermostat_daily_program_id: ID of the thermostat daily program that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -110,9 +102,7 @@ class AbstractAsyncThermostatsDailyPrograms(abc.ABC):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
 
@@ -123,7 +113,7 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -137,9 +127,7 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
         :param periods: Array of thermostat daily program periods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -148,11 +136,6 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
             json_payload["name"] = name
         if periods is not None:
             json_payload["periods"] = periods
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/create"
-            )
 
         res = self.client.post("/thermostats/daily_programs/create", json=json_payload)
 
@@ -164,24 +147,18 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, thermostat_daily_program_id: str) -> None:
         """Deletes a thermostat daily program.
 
         :param thermostat_daily_program_id: ID of the thermostat daily program that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if thermostat_daily_program_id is not None:
             params["thermostat_daily_program_id"] = thermostat_daily_program_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/delete"
-            )
 
         self.client.delete("/thermostats/daily_programs/delete", params=params)
 
@@ -189,7 +166,7 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -210,9 +187,7 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -221,11 +196,6 @@ class ThermostatsDailyPrograms(AbstractThermostatsDailyPrograms):
             json_payload["periods"] = periods
         if thermostat_daily_program_id is not None:
             json_payload["thermostat_daily_program_id"] = thermostat_daily_program_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/update"
-            )
 
         res = self.client.patch("/thermostats/daily_programs/update", json=json_payload)
 
@@ -251,7 +221,7 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -265,9 +235,7 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
         :param periods: Array of thermostat daily program periods.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -276,11 +244,6 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
             json_payload["name"] = name
         if periods is not None:
             json_payload["periods"] = periods
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/create"
-            )
 
         res = await self.client.post(
             "/thermostats/daily_programs/create", json=json_payload
@@ -294,24 +257,18 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, thermostat_daily_program_id: str) -> None:
         """Deletes a thermostat daily program.
 
         :param thermostat_daily_program_id: ID of the thermostat daily program that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if thermostat_daily_program_id is not None:
             params["thermostat_daily_program_id"] = thermostat_daily_program_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/delete"
-            )
 
         await self.client.delete("/thermostats/daily_programs/delete", params=params)
 
@@ -319,7 +276,7 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
     @route_metadata(
         path="/thermostats/daily_programs/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -340,9 +297,7 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
 
         :param wait_for_action_attempt: Whether, and for how long, to wait for the action attempt to finish.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -351,11 +306,6 @@ class AsyncThermostatsDailyPrograms(AbstractAsyncThermostatsDailyPrograms):
             json_payload["periods"] = periods
         if thermostat_daily_program_id is not None:
             json_payload["thermostat_daily_program_id"] = thermostat_daily_program_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/daily_programs/update"
-            )
 
         res = await self.client.patch(
             "/thermostats/daily_programs/update", json=json_payload

--- a/seam/routes/thermostats_schedules.py
+++ b/seam/routes/thermostats_schedules.py
@@ -38,9 +38,7 @@ class AbstractThermostatsSchedules(abc.ABC):
 
         :param name: Name of the thermostat schedule.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -48,8 +46,7 @@ class AbstractThermostatsSchedules(abc.ABC):
         """Deletes a `thermostat schedule <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules>`_ for a specified `thermostat <https://docs.seam.co/capability-guides/thermostats>`_.
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -58,9 +55,7 @@ class AbstractThermostatsSchedules(abc.ABC):
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -73,9 +68,7 @@ class AbstractThermostatsSchedules(abc.ABC):
 
         :param user_identifier_key: User identifier key by which to filter the list of returned thermostat schedules.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -105,8 +98,7 @@ class AbstractThermostatsSchedules(abc.ABC):
         :param name: Name of the thermostat schedule.
 
         :param starts_at: Date and time at which the thermostat schedule starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -140,9 +132,7 @@ class AbstractAsyncThermostatsSchedules(abc.ABC):
 
         :param name: Name of the thermostat schedule.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -150,8 +140,7 @@ class AbstractAsyncThermostatsSchedules(abc.ABC):
         """Deletes a `thermostat schedule <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules>`_ for a specified `thermostat <https://docs.seam.co/capability-guides/thermostats>`_.
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -160,9 +149,7 @@ class AbstractAsyncThermostatsSchedules(abc.ABC):
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -175,9 +162,7 @@ class AbstractAsyncThermostatsSchedules(abc.ABC):
 
         :param user_identifier_key: User identifier key by which to filter the list of returned thermostat schedules.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -207,8 +192,7 @@ class AbstractAsyncThermostatsSchedules(abc.ABC):
         :param name: Name of the thermostat schedule.
 
         :param starts_at: Date and time at which the thermostat schedule starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -219,7 +203,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -249,9 +233,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
         :param name: Name of the thermostat schedule.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -269,11 +251,6 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/create"
-            )
-
         res = self.client.post("/thermostats/schedules/create", json=json_payload)
 
         return ThermostatSchedule.from_dict(
@@ -282,24 +259,18 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, thermostat_schedule_id: str) -> None:
         """Deletes a `thermostat schedule <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules>`_ for a specified `thermostat <https://docs.seam.co/capability-guides/thermostats>`_.
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
             params["thermostat_schedule_id"] = thermostat_schedule_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/delete"
-            )
 
         self.client.delete("/thermostats/schedules/delete", params=params)
 
@@ -307,7 +278,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, thermostat_schedule_id: str) -> ThermostatSchedule:
@@ -315,18 +286,11 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
             params["thermostat_schedule_id"] = thermostat_schedule_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/get"
-            )
 
         res = self.client.get("/thermostats/schedules/get", params=params)
 
@@ -336,7 +300,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list(
@@ -348,20 +312,13 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
         :param user_identifier_key: User identifier key by which to filter the list of returned thermostat schedules.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/list"
-            )
 
         res = self.client.get("/thermostats/schedules/list", params=params)
 
@@ -374,7 +331,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -403,8 +360,7 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
         :param name: Name of the thermostat schedule.
 
         :param starts_at: Date and time at which the thermostat schedule starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
@@ -422,11 +378,6 @@ class ThermostatsSchedules(AbstractThermostatsSchedules):
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/update"
-            )
-
         self.client.patch("/thermostats/schedules/update", json=json_payload)
 
         return None
@@ -439,7 +390,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/create",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -469,9 +420,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
         :param name: Name of the thermostat schedule.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if climate_preset_key is not None:
@@ -489,11 +438,6 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
         if name is not None:
             json_payload["name"] = name
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/create"
-            )
-
         res = await self.client.post("/thermostats/schedules/create", json=json_payload)
 
         return ThermostatSchedule.from_dict(
@@ -502,24 +446,18 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, thermostat_schedule_id: str) -> None:
         """Deletes a `thermostat schedule <https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules>`_ for a specified `thermostat <https://docs.seam.co/capability-guides/thermostats>`_.
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
             params["thermostat_schedule_id"] = thermostat_schedule_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/delete"
-            )
 
         await self.client.delete("/thermostats/schedules/delete", params=params)
 
@@ -527,7 +465,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, thermostat_schedule_id: str) -> ThermostatSchedule:
@@ -535,18 +473,11 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
         :param thermostat_schedule_id: ID of the thermostat schedule that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
             params["thermostat_schedule_id"] = thermostat_schedule_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/get"
-            )
 
         res = await self.client.get("/thermostats/schedules/get", params=params)
 
@@ -556,7 +487,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/list",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list(
@@ -568,20 +499,13 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
         :param user_identifier_key: User identifier key by which to filter the list of returned thermostat schedules.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
         if user_identifier_key is not None:
             params["user_identifier_key"] = user_identifier_key
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/list"
-            )
 
         res = await self.client.get("/thermostats/schedules/list", params=params)
 
@@ -594,7 +518,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
 
     @route_metadata(
         path="/thermostats/schedules/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -623,8 +547,7 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
         :param name: Name of the thermostat schedule.
 
         :param starts_at: Date and time at which the thermostat schedule starts, in `ISO 8601 <https://www.iso.org/iso-8601-date-and-time-format.html>`_ format.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if thermostat_schedule_id is not None:
@@ -641,11 +564,6 @@ class AsyncThermostatsSchedules(AbstractAsyncThermostatsSchedules):
             json_payload["name"] = name
         if starts_at is not None:
             json_payload["starts_at"] = starts_at
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/schedules/update"
-            )
 
         await self.client.patch("/thermostats/schedules/update", json=json_payload)
 

--- a/seam/routes/thermostats_simulate.py
+++ b/seam/routes/thermostats_simulate.py
@@ -30,8 +30,7 @@ class AbstractThermostatsSimulate(abc.ABC):
         :param heating_set_point_celsius: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °C that you want to simulate. You must set ``heating_set_point_celsius`` or ``heating_set_point_fahrenheit``.
 
         :param heating_set_point_fahrenheit: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °F that you want to simulate. You must set ``heating_set_point_fahrenheit`` or ``heating_set_point_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -49,8 +48,7 @@ class AbstractThermostatsSimulate(abc.ABC):
         :param temperature_celsius: Temperature in °C that you want simulate the thermostat reaching. You must set ``temperature_celsius`` or ``temperature_fahrenheit``.
 
         :param temperature_fahrenheit: Temperature in °F that you want simulate the thermostat reaching. You must set ``temperature_fahrenheit`` or ``temperature_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -80,8 +78,7 @@ class AbstractAsyncThermostatsSimulate(abc.ABC):
         :param heating_set_point_celsius: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °C that you want to simulate. You must set ``heating_set_point_celsius`` or ``heating_set_point_fahrenheit``.
 
         :param heating_set_point_fahrenheit: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °F that you want to simulate. You must set ``heating_set_point_fahrenheit`` or ``heating_set_point_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -99,8 +96,7 @@ class AbstractAsyncThermostatsSimulate(abc.ABC):
         :param temperature_celsius: Temperature in °C that you want simulate the thermostat reaching. You must set ``temperature_celsius`` or ``temperature_fahrenheit``.
 
         :param temperature_fahrenheit: Temperature in °F that you want simulate the thermostat reaching. You must set ``temperature_fahrenheit`` or ``temperature_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -111,7 +107,7 @@ class ThermostatsSimulate(AbstractThermostatsSimulate):
 
     @route_metadata(
         path="/thermostats/simulate/hvac_mode_adjusted",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def hvac_mode_adjusted(
@@ -137,8 +133,7 @@ class ThermostatsSimulate(AbstractThermostatsSimulate):
         :param heating_set_point_celsius: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °C that you want to simulate. You must set ``heating_set_point_celsius`` or ``heating_set_point_fahrenheit``.
 
         :param heating_set_point_fahrenheit: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °F that you want to simulate. You must set ``heating_set_point_fahrenheit`` or ``heating_set_point_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -154,18 +149,13 @@ class ThermostatsSimulate(AbstractThermostatsSimulate):
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/simulate/hvac_mode_adjusted"
-            )
-
         self.client.post("/thermostats/simulate/hvac_mode_adjusted", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/thermostats/simulate/temperature_reached",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def temperature_reached(
@@ -182,8 +172,7 @@ class ThermostatsSimulate(AbstractThermostatsSimulate):
         :param temperature_celsius: Temperature in °C that you want simulate the thermostat reaching. You must set ``temperature_celsius`` or ``temperature_fahrenheit``.
 
         :param temperature_fahrenheit: Temperature in °F that you want simulate the thermostat reaching. You must set ``temperature_fahrenheit`` or ``temperature_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -192,11 +181,6 @@ class ThermostatsSimulate(AbstractThermostatsSimulate):
             json_payload["temperature_celsius"] = temperature_celsius
         if temperature_fahrenheit is not None:
             json_payload["temperature_fahrenheit"] = temperature_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/simulate/temperature_reached"
-            )
 
         self.client.post("/thermostats/simulate/temperature_reached", json=json_payload)
 
@@ -210,7 +194,7 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
 
     @route_metadata(
         path="/thermostats/simulate/hvac_mode_adjusted",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def hvac_mode_adjusted(
@@ -236,8 +220,7 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
         :param heating_set_point_celsius: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °C that you want to simulate. You must set ``heating_set_point_celsius`` or ``heating_set_point_fahrenheit``.
 
         :param heating_set_point_fahrenheit: Heating `set point <https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points>`_ in °F that you want to simulate. You must set ``heating_set_point_fahrenheit`` or ``heating_set_point_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -253,11 +236,6 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
         if heating_set_point_fahrenheit is not None:
             json_payload["heating_set_point_fahrenheit"] = heating_set_point_fahrenheit
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/simulate/hvac_mode_adjusted"
-            )
-
         await self.client.post(
             "/thermostats/simulate/hvac_mode_adjusted", json=json_payload
         )
@@ -266,7 +244,7 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
 
     @route_metadata(
         path="/thermostats/simulate/temperature_reached",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def temperature_reached(
@@ -283,8 +261,7 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
         :param temperature_celsius: Temperature in °C that you want simulate the thermostat reaching. You must set ``temperature_celsius`` or ``temperature_fahrenheit``.
 
         :param temperature_fahrenheit: Temperature in °F that you want simulate the thermostat reaching. You must set ``temperature_fahrenheit`` or ``temperature_celsius``.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -293,11 +270,6 @@ class AsyncThermostatsSimulate(AbstractAsyncThermostatsSimulate):
             json_payload["temperature_celsius"] = temperature_celsius
         if temperature_fahrenheit is not None:
             json_payload["temperature_fahrenheit"] = temperature_fahrenheit
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /thermostats/simulate/temperature_reached"
-            )
 
         await self.client.post(
             "/thermostats/simulate/temperature_reached", json=json_payload

--- a/seam/routes/user_identities.py
+++ b/seam/routes/user_identities.py
@@ -47,8 +47,7 @@ class AbstractUserIdentities(abc.ABC):
         :param user_identity_id: ID of the user identity to which you want to add an access system user.
 
         :param user_identity_key: Key of the user identity to which you want to add an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -80,9 +79,7 @@ class AbstractUserIdentities(abc.ABC):
     def delete(self, *, user_identity_id: str) -> None:
         """Deletes a specified `user identity <https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity>`_. This deletes the user identity and all associated resources, including any `credentials <https://docs.seam.co/api/acs/credentials>`_, `acs users <https://docs.seam.co/api/acs/users>`_ and `client sessions <https://docs.seam.co/api/client_sessions>`_.
 
-        :param user_identity_id: ID of the user identity that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_id: ID of the user identity that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -101,9 +98,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param max_use_count: Maximum number of times the instant key can be used. Default: 1.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -131,8 +126,7 @@ class AbstractUserIdentities(abc.ABC):
         :param device_id: ID of the managed device to which you want to grant access to the user identity.
 
         :param user_identity_id: ID of the user identity that you want to grant access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -169,9 +163,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible devices.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -180,9 +172,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -191,9 +181,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -202,9 +190,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -242,8 +228,7 @@ class AbstractUserIdentities(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from the user identity..
 
         :param user_identity_id: ID of the user identity from which you want to remove an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -253,8 +238,7 @@ class AbstractUserIdentities(abc.ABC):
         :param device_id: ID of the managed device to which you want to revoke access from the user identity.
 
         :param user_identity_id: ID of the user identity from which you want to revoke access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -277,9 +261,7 @@ class AbstractUserIdentities(abc.ABC):
 
         :param phone_number: Unique phone number for the user identity.
 
-        :param user_identity_key: Unique key for the user identity.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_key: Unique key for the user identity."""
         raise NotImplementedError()
 
 
@@ -309,8 +291,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
         :param user_identity_id: ID of the user identity to which you want to add an access system user.
 
         :param user_identity_key: Key of the user identity to which you want to add an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -342,9 +323,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
     async def delete(self, *, user_identity_id: str) -> None:
         """Deletes a specified `user identity <https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity>`_. This deletes the user identity and all associated resources, including any `credentials <https://docs.seam.co/api/acs/credentials>`_, `acs users <https://docs.seam.co/api/acs/users>`_ and `client sessions <https://docs.seam.co/api/client_sessions>`_.
 
-        :param user_identity_id: ID of the user identity that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_id: ID of the user identity that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -363,9 +342,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param max_use_count: Maximum number of times the instant key can be used. Default: 1.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -395,8 +372,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
         :param device_id: ID of the managed device to which you want to grant access to the user identity.
 
         :param user_identity_id: ID of the user identity that you want to grant access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -433,9 +409,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible devices.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -446,9 +420,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -457,9 +429,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -468,9 +438,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -508,8 +476,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
         :param acs_user_id: ID of the access system user that you want to remove from the user identity..
 
         :param user_identity_id: ID of the user identity from which you want to remove an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -521,8 +488,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
         :param device_id: ID of the managed device to which you want to revoke access from the user identity.
 
         :param user_identity_id: ID of the user identity from which you want to revoke access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -545,9 +511,7 @@ class AbstractAsyncUserIdentities(abc.ABC):
 
         :param phone_number: Unique phone number for the user identity.
 
-        :param user_identity_key: Unique key for the user identity.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_key: Unique key for the user identity."""
         raise NotImplementedError()
 
 
@@ -563,7 +527,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/add_acs_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def add_acs_user(
@@ -584,8 +548,7 @@ class UserIdentities(AbstractUserIdentities):
         :param user_identity_id: ID of the user identity to which you want to add an access system user.
 
         :param user_identity_key: Key of the user identity to which you want to add an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_user_id is not None:
@@ -595,18 +558,13 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/add_acs_user"
-            )
-
         self.client.put("/user_identities/add_acs_user", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/user_identities/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def create(
@@ -652,24 +610,17 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def delete(self, *, user_identity_id: str) -> None:
         """Deletes a specified `user identity <https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity>`_. This deletes the user identity and all associated resources, including any `credentials <https://docs.seam.co/api/acs/credentials>`_, `acs users <https://docs.seam.co/api/acs/users>`_ and `client sessions <https://docs.seam.co/api/client_sessions>`_.
 
-        :param user_identity_id: ID of the user identity that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_id: ID of the user identity that you want to delete."""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/delete"
-            )
 
         self.client.delete("/user_identities/delete", params=params)
 
@@ -677,7 +628,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/generate_instant_key",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def generate_instant_key(
@@ -695,9 +646,7 @@ class UserIdentities(AbstractUserIdentities):
 
         :param max_use_count: Maximum number of times the instant key can be used. Default: 1.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -706,11 +655,6 @@ class UserIdentities(AbstractUserIdentities):
             json_payload["customization_profile_id"] = customization_profile_id
         if max_use_count is not None:
             json_payload["max_use_count"] = max_use_count
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/generate_instant_key"
-            )
 
         res = self.client.post(
             "/user_identities/generate_instant_key", json=json_payload
@@ -721,7 +665,12 @@ class UserIdentities(AbstractUserIdentities):
         )
 
     @route_metadata(
-        path="/user_identities/get", has_required_parameters=True, has_pagination=False
+        path="/user_identities/get",
+        at_least_one_parameter_names=(
+            "user_identity_id",
+            "user_identity_key",
+        ),
+        has_pagination=False,
     )
     def get(
         self,
@@ -745,7 +694,13 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_key is not None:
             params["user_identity_key"] = user_identity_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                user_identity_id,
+                user_identity_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /user_identities/get"
             )
@@ -758,7 +713,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/grant_access_to_device",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def grant_access_to_device(self, *, device_id: str, user_identity_id: str) -> None:
@@ -767,8 +722,7 @@ class UserIdentities(AbstractUserIdentities):
         :param device_id: ID of the managed device to which you want to grant access to the user identity.
 
         :param user_identity_id: ID of the user identity that you want to grant access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -776,17 +730,14 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/grant_access_to_device"
-            )
-
         self.client.put("/user_identities/grant_access_to_device", json=json_payload)
 
         return None
 
     @route_metadata(
-        path="/user_identities/list", has_required_parameters=False, has_pagination=True
+        path="/user_identities/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     def list(
         self,
@@ -839,7 +790,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_accessible_devices(self, *, user_identity_id: str) -> List[Device]:
@@ -847,18 +798,11 @@ class UserIdentities(AbstractUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible devices.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_accessible_devices"
-            )
 
         res = self.client.get("/user_identities/list_accessible_devices", params=params)
 
@@ -871,7 +815,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_accessible_entrances(self, *, user_identity_id: str) -> List[AcsEntrance]:
@@ -879,18 +823,11 @@ class UserIdentities(AbstractUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_accessible_entrances"
-            )
 
         res = self.client.get(
             "/user_identities/list_accessible_entrances", params=params
@@ -905,7 +842,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_acs_systems",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_acs_systems(self, *, user_identity_id: str) -> List[AcsSystem]:
@@ -913,18 +850,11 @@ class UserIdentities(AbstractUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_acs_systems"
-            )
 
         res = self.client.get("/user_identities/list_acs_systems", params=params)
 
@@ -937,7 +867,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_acs_users",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def list_acs_users(self, *, user_identity_id: str) -> List[AcsUser]:
@@ -945,18 +875,11 @@ class UserIdentities(AbstractUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_acs_users"
-            )
 
         res = self.client.get("/user_identities/list_acs_users", params=params)
 
@@ -967,7 +890,12 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/merge",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "merged_user_identity_ids",
+            "merged_user_identity_keys",
+            "user_identity_id",
+            "user_identity_key",
+        ),
         has_pagination=False,
     )
     def merge(
@@ -1006,7 +934,15 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                merged_user_identity_ids,
+                merged_user_identity_keys,
+                user_identity_id,
+                user_identity_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /user_identities/merge"
             )
@@ -1017,7 +953,7 @@ class UserIdentities(AbstractUserIdentities):
 
     @route_metadata(
         path="/user_identities/remove_acs_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def remove_acs_user(self, *, acs_user_id: str, user_identity_id: str) -> None:
@@ -1026,8 +962,7 @@ class UserIdentities(AbstractUserIdentities):
         :param acs_user_id: ID of the access system user that you want to remove from the user identity..
 
         :param user_identity_id: ID of the user identity from which you want to remove an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_user_id is not None:
@@ -1035,18 +970,13 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/remove_acs_user"
-            )
-
         self.client.delete("/user_identities/remove_acs_user", params=params)
 
         return None
 
     @route_metadata(
         path="/user_identities/revoke_access_to_device",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def revoke_access_to_device(self, *, device_id: str, user_identity_id: str) -> None:
@@ -1055,8 +985,7 @@ class UserIdentities(AbstractUserIdentities):
         :param device_id: ID of the managed device to which you want to revoke access from the user identity.
 
         :param user_identity_id: ID of the user identity from which you want to revoke access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if device_id is not None:
@@ -1064,18 +993,13 @@ class UserIdentities(AbstractUserIdentities):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/revoke_access_to_device"
-            )
-
         self.client.delete("/user_identities/revoke_access_to_device", params=params)
 
         return None
 
     @route_metadata(
         path="/user_identities/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -1097,9 +1021,7 @@ class UserIdentities(AbstractUserIdentities):
 
         :param phone_number: Unique phone number for the user identity.
 
-        :param user_identity_key: Unique key for the user identity.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_key: Unique key for the user identity."""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -1112,11 +1034,6 @@ class UserIdentities(AbstractUserIdentities):
             json_payload["phone_number"] = phone_number
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/update"
-            )
 
         self.client.patch("/user_identities/update", json=json_payload)
 
@@ -1135,7 +1052,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/add_acs_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def add_acs_user(
@@ -1156,8 +1073,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         :param user_identity_id: ID of the user identity to which you want to add an access system user.
 
         :param user_identity_key: Key of the user identity to which you want to add an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if acs_user_id is not None:
@@ -1167,18 +1083,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/add_acs_user"
-            )
-
         await self.client.put("/user_identities/add_acs_user", json=json_payload)
 
         return None
 
     @route_metadata(
         path="/user_identities/create",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def create(
@@ -1224,24 +1135,17 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/delete",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def delete(self, *, user_identity_id: str) -> None:
         """Deletes a specified `user identity <https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity>`_. This deletes the user identity and all associated resources, including any `credentials <https://docs.seam.co/api/acs/credentials>`_, `acs users <https://docs.seam.co/api/acs/users>`_ and `client sessions <https://docs.seam.co/api/client_sessions>`_.
 
-        :param user_identity_id: ID of the user identity that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_id: ID of the user identity that you want to delete."""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/delete"
-            )
 
         await self.client.delete("/user_identities/delete", params=params)
 
@@ -1249,7 +1153,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/generate_instant_key",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def generate_instant_key(
@@ -1267,9 +1171,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param max_use_count: Maximum number of times the instant key can be used. Default: 1.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -1278,11 +1180,6 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
             json_payload["customization_profile_id"] = customization_profile_id
         if max_use_count is not None:
             json_payload["max_use_count"] = max_use_count
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/generate_instant_key"
-            )
 
         res = await self.client.post(
             "/user_identities/generate_instant_key", json=json_payload
@@ -1293,7 +1190,12 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         )
 
     @route_metadata(
-        path="/user_identities/get", has_required_parameters=True, has_pagination=False
+        path="/user_identities/get",
+        at_least_one_parameter_names=(
+            "user_identity_id",
+            "user_identity_key",
+        ),
+        has_pagination=False,
     )
     async def get(
         self,
@@ -1317,7 +1219,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         if user_identity_key is not None:
             params["user_identity_key"] = user_identity_key
 
-        if not params:
+        if all(
+            param is None
+            for param in (
+                user_identity_id,
+                user_identity_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /user_identities/get"
             )
@@ -1330,7 +1238,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/grant_access_to_device",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def grant_access_to_device(
@@ -1341,19 +1249,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         :param device_id: ID of the managed device to which you want to grant access to the user identity.
 
         :param user_identity_id: ID of the user identity that you want to grant access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if device_id is not None:
             json_payload["device_id"] = device_id
         if user_identity_id is not None:
             json_payload["user_identity_id"] = user_identity_id
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/grant_access_to_device"
-            )
 
         await self.client.put(
             "/user_identities/grant_access_to_device", json=json_payload
@@ -1362,7 +1264,9 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         return None
 
     @route_metadata(
-        path="/user_identities/list", has_required_parameters=False, has_pagination=True
+        path="/user_identities/list",
+        at_least_one_parameter_names=(),
+        has_pagination=True,
     )
     async def list(
         self,
@@ -1415,7 +1319,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_accessible_devices(self, *, user_identity_id: str) -> List[Device]:
@@ -1423,18 +1327,11 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible devices.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_accessible_devices"
-            )
 
         res = await self.client.get(
             "/user_identities/list_accessible_devices", params=params
@@ -1449,7 +1346,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_accessible_entrances",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_accessible_entrances(
@@ -1459,18 +1356,11 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all accessible entrances.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_accessible_entrances"
-            )
 
         res = await self.client.get(
             "/user_identities/list_accessible_entrances", params=params
@@ -1485,7 +1375,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_acs_systems",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_acs_systems(self, *, user_identity_id: str) -> List[AcsSystem]:
@@ -1493,18 +1383,11 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access systems.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_acs_systems"
-            )
 
         res = await self.client.get("/user_identities/list_acs_systems", params=params)
 
@@ -1517,7 +1400,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/list_acs_users",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def list_acs_users(self, *, user_identity_id: str) -> List[AcsUser]:
@@ -1525,18 +1408,11 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param user_identity_id: ID of the user identity for which you want to retrieve all access system users.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/list_acs_users"
-            )
 
         res = await self.client.get("/user_identities/list_acs_users", params=params)
 
@@ -1547,7 +1423,12 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/merge",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(
+            "merged_user_identity_ids",
+            "merged_user_identity_keys",
+            "user_identity_id",
+            "user_identity_key",
+        ),
         has_pagination=False,
     )
     async def merge(
@@ -1586,7 +1467,15 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
 
-        if not json_payload:
+        if all(
+            param is None
+            for param in (
+                merged_user_identity_ids,
+                merged_user_identity_keys,
+                user_identity_id,
+                user_identity_key,
+            )
+        ):
             raise ValueError(
                 "At least one parameter is required for /user_identities/merge"
             )
@@ -1597,7 +1486,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/remove_acs_user",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def remove_acs_user(self, *, acs_user_id: str, user_identity_id: str) -> None:
@@ -1606,8 +1495,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         :param acs_user_id: ID of the access system user that you want to remove from the user identity..
 
         :param user_identity_id: ID of the user identity from which you want to remove an access system user.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if acs_user_id is not None:
@@ -1615,18 +1503,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
 
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/remove_acs_user"
-            )
-
         await self.client.delete("/user_identities/remove_acs_user", params=params)
 
         return None
 
     @route_metadata(
         path="/user_identities/revoke_access_to_device",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def revoke_access_to_device(
@@ -1637,19 +1520,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
         :param device_id: ID of the managed device to which you want to revoke access from the user identity.
 
         :param user_identity_id: ID of the user identity from which you want to revoke access to a device.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         params: Dict[str, Any] = {}
 
         if device_id is not None:
             params["device_id"] = device_id
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/revoke_access_to_device"
-            )
 
         await self.client.delete(
             "/user_identities/revoke_access_to_device", params=params
@@ -1659,7 +1536,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
     @route_metadata(
         path="/user_identities/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -1681,9 +1558,7 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         :param phone_number: Unique phone number for the user identity.
 
-        :param user_identity_key: Unique key for the user identity.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param user_identity_key: Unique key for the user identity."""
         json_payload: Dict[str, Any] = {}
 
         if user_identity_id is not None:
@@ -1696,11 +1571,6 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
             json_payload["phone_number"] = phone_number
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/update"
-            )
 
         await self.client.patch("/user_identities/update", json=json_payload)
 

--- a/seam/routes/user_identities_unmanaged.py
+++ b/seam/routes/user_identities_unmanaged.py
@@ -16,9 +16,7 @@ class AbstractUserIdentitiesUnmanaged(abc.ABC):
 
         :param user_identity_id: ID of the unmanaged user identity that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -60,8 +58,7 @@ class AbstractUserIdentitiesUnmanaged(abc.ABC):
         :param user_identity_id: ID of the unmanaged user identity that you want to update.
 
         :param user_identity_key: Unique key for the user identity. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -73,9 +70,7 @@ class AbstractAsyncUserIdentitiesUnmanaged(abc.ABC):
 
         :param user_identity_id: ID of the unmanaged user identity that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -117,8 +112,7 @@ class AbstractAsyncUserIdentitiesUnmanaged(abc.ABC):
         :param user_identity_id: ID of the unmanaged user identity that you want to update.
 
         :param user_identity_key: Unique key for the user identity. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         raise NotImplementedError()
 
 
@@ -129,7 +123,7 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def get(self, *, user_identity_id: str) -> UnmanagedUserIdentity:
@@ -137,18 +131,11 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
         :param user_identity_id: ID of the unmanaged user identity that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/unmanaged/get"
-            )
 
         res = self.client.get("/user_identities/unmanaged/get", params=params)
 
@@ -158,7 +145,7 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     def list(
@@ -202,7 +189,7 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def update(
@@ -221,8 +208,7 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
         :param user_identity_id: ID of the unmanaged user identity that you want to update.
 
         :param user_identity_key: Unique key for the user identity. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if is_managed is not None:
@@ -231,11 +217,6 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
             json_payload["user_identity_id"] = user_identity_id
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/unmanaged/update"
-            )
 
         self.client.patch("/user_identities/unmanaged/update", json=json_payload)
 
@@ -249,7 +230,7 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/get",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def get(self, *, user_identity_id: str) -> UnmanagedUserIdentity:
@@ -257,18 +238,11 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
         :param user_identity_id: ID of the unmanaged user identity that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if user_identity_id is not None:
             params["user_identity_id"] = user_identity_id
-
-        if not params:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/unmanaged/get"
-            )
 
         res = await self.client.get("/user_identities/unmanaged/get", params=params)
 
@@ -278,7 +252,7 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/list",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=True,
     )
     async def list(
@@ -322,7 +296,7 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
     @route_metadata(
         path="/user_identities/unmanaged/update",
-        has_required_parameters=True,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def update(
@@ -341,8 +315,7 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
         :param user_identity_id: ID of the unmanaged user identity that you want to update.
 
         :param user_identity_key: Unique key for the user identity. If not provided, the existing key will be preserved.
-
-        :raises ValueError: At least one parameter must be provided."""
+        """
         json_payload: Dict[str, Any] = {}
 
         if is_managed is not None:
@@ -351,11 +324,6 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
             json_payload["user_identity_id"] = user_identity_id
         if user_identity_key is not None:
             json_payload["user_identity_key"] = user_identity_key
-
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /user_identities/unmanaged/update"
-            )
 
         await self.client.patch("/user_identities/unmanaged/update", json=json_payload)
 

--- a/seam/routes/webhooks.py
+++ b/seam/routes/webhooks.py
@@ -17,18 +17,14 @@ class AbstractWebhooks(abc.ABC):
 
         :param event_types: Types of events that you want the new webhook to receive.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     def delete(self, *, webhook_id: str) -> None:
         """Deletes a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
-        :param webhook_id: ID of the webhook that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -37,9 +33,7 @@ class AbstractWebhooks(abc.ABC):
 
         :param webhook_id: ID of the webhook that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -55,9 +49,7 @@ class AbstractWebhooks(abc.ABC):
 
         :param event_types: Types of events that you want the webhook to receive.
 
-        :param webhook_id: ID of the webhook that you want to update.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to update."""
         raise NotImplementedError()
 
 
@@ -73,18 +65,14 @@ class AbstractAsyncWebhooks(abc.ABC):
 
         :param event_types: Types of events that you want the new webhook to receive.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def delete(self, *, webhook_id: str) -> None:
         """Deletes a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
-        :param webhook_id: ID of the webhook that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to delete."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -93,9 +81,7 @@ class AbstractAsyncWebhooks(abc.ABC):
 
         :param webhook_id: ID of the webhook that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -111,9 +97,7 @@ class AbstractAsyncWebhooks(abc.ABC):
 
         :param event_types: Types of events that you want the webhook to receive.
 
-        :param webhook_id: ID of the webhook that you want to update.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to update."""
         raise NotImplementedError()
 
 
@@ -123,7 +107,7 @@ class Webhooks(AbstractWebhooks):
         self.defaults = defaults
 
     @route_metadata(
-        path="/webhooks/create", has_required_parameters=True, has_pagination=False
+        path="/webhooks/create", at_least_one_parameter_names=(), has_pagination=False
     )
     def create(self, *, url: str, event_types: Optional[List[str]] = None) -> Webhook:
         """Creates a new `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
@@ -132,9 +116,7 @@ class Webhooks(AbstractWebhooks):
 
         :param event_types: Types of events that you want the new webhook to receive.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if url is not None:
@@ -142,59 +124,46 @@ class Webhooks(AbstractWebhooks):
         if event_types is not None:
             json_payload["event_types"] = event_types
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /webhooks/create")
-
         res = self.client.post("/webhooks/create", json=json_payload)
 
         return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/create"))
 
     @route_metadata(
-        path="/webhooks/delete", has_required_parameters=True, has_pagination=False
+        path="/webhooks/delete", at_least_one_parameter_names=(), has_pagination=False
     )
     def delete(self, *, webhook_id: str) -> None:
         """Deletes a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
-        :param webhook_id: ID of the webhook that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to delete."""
         params: Dict[str, Any] = {}
 
         if webhook_id is not None:
             params["webhook_id"] = webhook_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /webhooks/delete")
 
         self.client.delete("/webhooks/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/webhooks/get", has_required_parameters=True, has_pagination=False
+        path="/webhooks/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self, *, webhook_id: str) -> Webhook:
         """Gets a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
         :param webhook_id: ID of the webhook that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if webhook_id is not None:
             params["webhook_id"] = webhook_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /webhooks/get")
 
         res = self.client.get("/webhooks/get", params=params)
 
         return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/get"))
 
     @route_metadata(
-        path="/webhooks/list", has_required_parameters=False, has_pagination=False
+        path="/webhooks/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(self) -> List[Webhook]:
         """Returns a list of all `webhooks <https://docs.seam.co/developer-tools/webhooks>`_.
@@ -210,25 +179,20 @@ class Webhooks(AbstractWebhooks):
         ]
 
     @route_metadata(
-        path="/webhooks/update", has_required_parameters=True, has_pagination=False
+        path="/webhooks/update", at_least_one_parameter_names=(), has_pagination=False
     )
     def update(self, *, event_types: List[str], webhook_id: str) -> None:
         """Updates a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
         :param event_types: Types of events that you want the webhook to receive.
 
-        :param webhook_id: ID of the webhook that you want to update.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to update."""
         json_payload: Dict[str, Any] = {}
 
         if event_types is not None:
             json_payload["event_types"] = event_types
         if webhook_id is not None:
             json_payload["webhook_id"] = webhook_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /webhooks/update")
 
         self.client.put("/webhooks/update", json=json_payload)
 
@@ -241,7 +205,7 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
         self.defaults = defaults
 
     @route_metadata(
-        path="/webhooks/create", has_required_parameters=True, has_pagination=False
+        path="/webhooks/create", at_least_one_parameter_names=(), has_pagination=False
     )
     async def create(
         self, *, url: str, event_types: Optional[List[str]] = None
@@ -252,9 +216,7 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
 
         :param event_types: Types of events that you want the new webhook to receive.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if url is not None:
@@ -262,59 +224,46 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
         if event_types is not None:
             json_payload["event_types"] = event_types
 
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /webhooks/create")
-
         res = await self.client.post("/webhooks/create", json=json_payload)
 
         return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/create"))
 
     @route_metadata(
-        path="/webhooks/delete", has_required_parameters=True, has_pagination=False
+        path="/webhooks/delete", at_least_one_parameter_names=(), has_pagination=False
     )
     async def delete(self, *, webhook_id: str) -> None:
         """Deletes a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
-        :param webhook_id: ID of the webhook that you want to delete.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to delete."""
         params: Dict[str, Any] = {}
 
         if webhook_id is not None:
             params["webhook_id"] = webhook_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /webhooks/delete")
 
         await self.client.delete("/webhooks/delete", params=params)
 
         return None
 
     @route_metadata(
-        path="/webhooks/get", has_required_parameters=True, has_pagination=False
+        path="/webhooks/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self, *, webhook_id: str) -> Webhook:
         """Gets a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
         :param webhook_id: ID of the webhook that you want to get.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         params: Dict[str, Any] = {}
 
         if webhook_id is not None:
             params["webhook_id"] = webhook_id
-
-        if not params:
-            raise ValueError("At least one parameter is required for /webhooks/get")
 
         res = await self.client.get("/webhooks/get", params=params)
 
         return Webhook.from_dict(unwrap(res, "webhook", "/webhooks/get"))
 
     @route_metadata(
-        path="/webhooks/list", has_required_parameters=False, has_pagination=False
+        path="/webhooks/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(self) -> List[Webhook]:
         """Returns a list of all `webhooks <https://docs.seam.co/developer-tools/webhooks>`_.
@@ -330,25 +279,20 @@ class AsyncWebhooks(AbstractAsyncWebhooks):
         ]
 
     @route_metadata(
-        path="/webhooks/update", has_required_parameters=True, has_pagination=False
+        path="/webhooks/update", at_least_one_parameter_names=(), has_pagination=False
     )
     async def update(self, *, event_types: List[str], webhook_id: str) -> None:
         """Updates a specified `webhook <https://docs.seam.co/developer-tools/webhooks>`_.
 
         :param event_types: Types of events that you want the webhook to receive.
 
-        :param webhook_id: ID of the webhook that you want to update.
-
-        :raises ValueError: At least one parameter must be provided."""
+        :param webhook_id: ID of the webhook that you want to update."""
         json_payload: Dict[str, Any] = {}
 
         if event_types is not None:
             json_payload["event_types"] = event_types
         if webhook_id is not None:
             json_payload["webhook_id"] = webhook_id
-
-        if not json_payload:
-            raise ValueError("At least one parameter is required for /webhooks/update")
 
         await self.client.put("/webhooks/update", json=json_payload)
 

--- a/seam/routes/workspaces.py
+++ b/seam/routes/workspaces.py
@@ -51,9 +51,7 @@ class AbstractWorkspaces(abc.ABC):
 
         :param webview_success_message: Deprecated: Use ``connect_webview_customization.webview_success_message`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -148,9 +146,7 @@ class AbstractAsyncWorkspaces(abc.ABC):
 
         :param webview_success_message: Deprecated: Use ``connect_webview_customization.webview_success_message`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -212,7 +208,7 @@ class Workspaces(AbstractWorkspaces):
         self.defaults = defaults
 
     @route_metadata(
-        path="/workspaces/create", has_required_parameters=True, has_pagination=False
+        path="/workspaces/create", at_least_one_parameter_names=(), has_pagination=False
     )
     def create(
         self,
@@ -250,9 +246,7 @@ class Workspaces(AbstractWorkspaces):
 
         :param webview_success_message: Deprecated: Use ``connect_webview_customization.webview_success_message`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -280,17 +274,12 @@ class Workspaces(AbstractWorkspaces):
         if webview_success_message is not None:
             json_payload["webview_success_message"] = webview_success_message
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /workspaces/create"
-            )
-
         res = self.client.post("/workspaces/create", json=json_payload)
 
         return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/create"))
 
     @route_metadata(
-        path="/workspaces/get", has_required_parameters=False, has_pagination=False
+        path="/workspaces/get", at_least_one_parameter_names=(), has_pagination=False
     )
     def get(self) -> Workspace:
         """Returns the `workspace <https://docs.seam.co/core-concepts/workspaces>`_ associated with the authentication value.
@@ -303,7 +292,7 @@ class Workspaces(AbstractWorkspaces):
         return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/get"))
 
     @route_metadata(
-        path="/workspaces/list", has_required_parameters=False, has_pagination=False
+        path="/workspaces/list", at_least_one_parameter_names=(), has_pagination=False
     )
     def list(self) -> List[Workspace]:
         """Returns a list of `workspaces <https://docs.seam.co/core-concepts/workspaces>`_ associated with the authentication value.
@@ -320,7 +309,7 @@ class Workspaces(AbstractWorkspaces):
 
     @route_metadata(
         path="/workspaces/reset_sandbox",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     def reset_sandbox(
@@ -350,7 +339,7 @@ class Workspaces(AbstractWorkspaces):
         )
 
     @route_metadata(
-        path="/workspaces/update", has_required_parameters=False, has_pagination=False
+        path="/workspaces/update", at_least_one_parameter_names=(), has_pagination=False
     )
     def update(
         self,
@@ -406,7 +395,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
         self.defaults = defaults
 
     @route_metadata(
-        path="/workspaces/create", has_required_parameters=True, has_pagination=False
+        path="/workspaces/create", at_least_one_parameter_names=(), has_pagination=False
     )
     async def create(
         self,
@@ -444,9 +433,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
         :param webview_success_message: Deprecated: Use ``connect_webview_customization.webview_success_message`` instead.
 
-        :returns: OK
-
-        :raises ValueError: At least one parameter must be provided."""
+        :returns: OK"""
         json_payload: Dict[str, Any] = {}
 
         if name is not None:
@@ -474,17 +461,12 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
         if webview_success_message is not None:
             json_payload["webview_success_message"] = webview_success_message
 
-        if not json_payload:
-            raise ValueError(
-                "At least one parameter is required for /workspaces/create"
-            )
-
         res = await self.client.post("/workspaces/create", json=json_payload)
 
         return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/create"))
 
     @route_metadata(
-        path="/workspaces/get", has_required_parameters=False, has_pagination=False
+        path="/workspaces/get", at_least_one_parameter_names=(), has_pagination=False
     )
     async def get(self) -> Workspace:
         """Returns the `workspace <https://docs.seam.co/core-concepts/workspaces>`_ associated with the authentication value.
@@ -497,7 +479,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
         return Workspace.from_dict(unwrap(res, "workspace", "/workspaces/get"))
 
     @route_metadata(
-        path="/workspaces/list", has_required_parameters=False, has_pagination=False
+        path="/workspaces/list", at_least_one_parameter_names=(), has_pagination=False
     )
     async def list(self) -> List[Workspace]:
         """Returns a list of `workspaces <https://docs.seam.co/core-concepts/workspaces>`_ associated with the authentication value.
@@ -514,7 +496,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
 
     @route_metadata(
         path="/workspaces/reset_sandbox",
-        has_required_parameters=False,
+        at_least_one_parameter_names=(),
         has_pagination=False,
     )
     async def reset_sandbox(
@@ -544,7 +526,7 @@ class AsyncWorkspaces(AbstractAsyncWorkspaces):
         )
 
     @route_metadata(
-        path="/workspaces/update", has_required_parameters=False, has_pagination=False
+        path="/workspaces/update", at_least_one_parameter_names=(), has_pagination=False
     )
     async def update(
         self,

--- a/seam/seam.py
+++ b/seam/seam.py
@@ -146,11 +146,12 @@ class Seam(AbstractSeam):
         if not getattr(request, "__seam_has_pagination__", False):
             raise ValueError("Cannot create a paginator for a non-paginated endpoint")
 
-        has_required_parameters = getattr(
-            request, "__seam_has_required_parameters__", False
+        at_least_one_parameter_names = getattr(
+            request, "__seam_at_least_one_parameter_names__", ()
         )
-        if has_required_parameters and (
-            not params or not any(value is not None for value in params.values())
+        if at_least_one_parameter_names and (
+            not params
+            or all(params.get(name) is None for name in at_least_one_parameter_names)
         ):
             path = getattr(request, "__seam_path__", "this endpoint")
             raise ValueError(f"At least one parameter is required for {path}")
@@ -394,11 +395,12 @@ class AsyncSeam(AbstractAsyncSeam):
         if not getattr(request, "__seam_has_pagination__", False):
             raise ValueError("Cannot create a paginator for a non-paginated endpoint")
 
-        has_required_parameters = getattr(
-            request, "__seam_has_required_parameters__", False
+        at_least_one_parameter_names = getattr(
+            request, "__seam_at_least_one_parameter_names__", ()
         )
-        if has_required_parameters and (
-            not params or not any(value is not None for value in params.values())
+        if at_least_one_parameter_names and (
+            not params
+            or all(params.get(name) is None for name in at_least_one_parameter_names)
         ):
             path = getattr(request, "__seam_path__", "this endpoint")
             raise ValueError(f"At least one parameter is required for {path}")

--- a/test/required_parameters_test.py
+++ b/test/required_parameters_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from seam import Seam
+
+
+def test_a_pagination_knob_does_not_satisfy_the_guard(seam: Seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        seam.access_codes.list(limit=20)
+
+
+def test_a_page_cursor_does_not_satisfy_the_guard(seam: Seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        seam.access_codes.list(page_cursor="some-cursor")
+
+
+def test_a_filter_parameter_satisfies_the_guard(seam: Seam, server):
+    _, seed = server
+
+    access_codes = seam.access_codes.list(device_id=seed["august_device_1"])
+
+    assert isinstance(access_codes, list)
+
+
+def test_an_unpaginated_endpoint_still_guards_its_filters(seam: Seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /events/list"
+    ):
+        seam.events.list(limit=5)
+
+
+def test_create_paginator_rejects_pagination_only_params(seam: Seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        seam.create_paginator(seam.access_codes.list, {"limit": 20})
+
+
+def test_create_paginator_rejects_a_page_cursor_alone(seam: Seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        seam.create_paginator(seam.access_codes.list, {"page_cursor": "some-cursor"})
+
+
+def test_create_paginator_accepts_a_filter_parameter(seam: Seam, server):
+    _, seed = server
+
+    paginator = seam.create_paginator(
+        seam.access_codes.list, {"device_id": seed["august_device_1"]}
+    )
+
+    assert isinstance(paginator.flatten_to_list(), list)
+
+
+async def test_a_pagination_knob_does_not_satisfy_the_guard_async(async_seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        await async_seam.access_codes.list(limit=20)
+
+
+async def test_create_paginator_rejects_pagination_only_params_async(async_seam):
+    with pytest.raises(
+        ValueError, match="At least one parameter is required for /access_codes/list"
+    ):
+        async_seam.create_paginator(async_seam.access_codes.list, {"limit": 20})


### PR DESCRIPTION
## What

The "at least one parameter is required" guard counted every parameter, so `seam.access_codes.list(limit=20)` satisfied a guard whose purpose is to require a *filter*, a page cursor alone satisfied it from page two onward, and `create_paginator` had a second hand-written copy with the same defect (SDK audit finding M7; ports JS #1008 / PHP #474 — pagination knobs are not filters).

- The codegen layout now computes an explicit `atLeastOneParameterNames` list — the endpoint's parameters minus `limit` and `page_cursor`, and only for endpoints where every parameter is optional (the same computation as the JS SDK). The generated guard checks exactly those names; nothing is emitted when the list is empty.
- Endpoints with an individually required parameter drop the blanket guard entirely — Python's own signature already enforces those, so the old `if not payload` there was dead code (JS made the same call). Their docstrings also lose the now-wrong `:raises ValueError` line.
- `@route_metadata` carries `at_least_one_parameter_names` instead of the boolean `has_required_parameters`, and both `create_paginator` guards (sync and async) consult the names, fixing the `{"limit": 20}` and page-cursor escapes there too.

This is a template + layout change; all route-file changes are regenerated output (guard raise sites go from 50 to 20 across the tree — the other 30 were the dead blanket guards).

**Stacked on [#638](https://github.com/seamapi/python/pull/638)** (both edit the same route-method template); diff shrinks as the stack merges.

## Testing

New `test/required_parameters_test.py` (sync + async): `limit`-only and `page_cursor`-only calls raise with the pinned message on both the route method and `create_paginator`; a real filter passes and paginates; the unpaginated `events.list(limit=5)` raises.

Revert check: with the old generated stack restored, the new tests fail with `DID NOT RAISE ValueError` — the audit's silent-pass symptom.

Full suite: 225 passed; mypy, pylint (10.00), black clean; regeneration is drift-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_