### PR TITLE
fix: Read pagination from the response instead of a client hook

### DIFF
--- a/codegen/layouts/partials/route-method.hbs
+++ b/codegen/layouts/partials/route-method.hbs
@@ -35,7 +35,10 @@
         return None
 {{else if (isListType returnType)}}
 
-        return [{{fromDict (listItemType returnType)}}(item) for item in unwrap_list(res, "{{returnPath.[0]}}", "{{path}}")]
+        return {{#if hasPagination}}PaginatedList(
+            [{{fromDict (listItemType returnType)}}(item) for item in unwrap_list(res, "{{returnPath.[0]}}", "{{path}}")],
+            pagination=res.get("pagination"),
+        ){{else}}[{{fromDict (listItemType returnType)}}(item) for item in unwrap_list(res, "{{returnPath.[0]}}", "{{path}}")]{{/if}}
 {{else}}
 
         return {{fromDict returnType}}(unwrap(res, "{{returnPath.[0]}}", "{{path}}"))

--- a/codegen/layouts/route.hbs
+++ b/codegen/layouts/route.hbs
@@ -20,6 +20,9 @@ from ..response import unwrap
 {{#if importUnwrapList}}
 from ..response import unwrap_list
 {{/if}}
+{{#if importPaginatedList}}
+from ..pagination import PaginatedList
+{{/if}}
 
 
 {{> abstract-route-class abstractClass}}

--- a/codegen/lib/layouts/route.ts
+++ b/codegen/lib/layouts/route.ts
@@ -64,6 +64,7 @@ export interface RouteLayoutContext {
   importNull: boolean
   importUnwrap: boolean
   importUnwrapList: boolean
+  importPaginatedList: boolean
   methods: MethodLayoutContext[]
 }
 
@@ -154,6 +155,8 @@ export const setRouteLayoutContext = (cls: ClassModel): RouteLayoutContext => {
       returnPath.length > 0 && returnType.startsWith('List['),
   )
 
+  const importPaginatedList = methods.some(({ hasPagination }) => hasPagination)
+
   const showPass =
     cls.methods.length === 0 && cls.childClassIdentifiers.length === 0
 
@@ -198,6 +201,7 @@ export const setRouteLayoutContext = (cls: ClassModel): RouteLayoutContext => {
     importNull,
     importUnwrap,
     importUnwrapList,
+    importPaginatedList,
     methods,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@seamapi/python",
       "devDependencies": {
         "@seamapi/blueprint": "^1.10.0",
-        "@seamapi/fake-seam-connect": "2.0.5",
+        "@seamapi/fake-seam-connect": "2.0.6",
         "@seamapi/smith": "^1.1.0",
         "@seamapi/types": "1.1047.0",
         "change-case": "^5.4.4",
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-2.0.5.tgz",
-      "integrity": "sha512-dnHoZtHUHyQP9yqduEqE8dfmOJGMMt0MuqviwgOZo8ElAaPoZk/G+QM5MDg2LJ6q0t54kARYjSngp+IfTme6TQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-2.0.6.tgz",
+      "integrity": "sha512-lwesSVm0AhQ57QuV52iGTI2qkK++phcY0K/xkalsUWdbwyPK4cj2VfJuW3yes32HuTaXkwPWlT9lrIhLJzZOnQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "packageManager": "npm@11.19.0",
   "devDependencies": {
     "@seamapi/blueprint": "^1.10.0",
-    "@seamapi/fake-seam-connect": "2.0.5",
+    "@seamapi/fake-seam-connect": "2.0.6",
     "@seamapi/smith": "^1.1.0",
     "@seamapi/types": "1.1047.0",
     "change-case": "^5.4.4",

--- a/seam/pagination.py
+++ b/seam/pagination.py
@@ -1,3 +1,6 @@
+from typing import Any, Dict, List, Optional
+
+
 class Pagination:
     def __init__(
         self,
@@ -8,3 +11,16 @@ class Pagination:
         self.has_next_page = has_next_page
         self.next_page_cursor = next_page_cursor
         self.next_page_url = next_page_url
+
+
+class PaginatedList(List[Any]):
+    """A list of results that carries the response's pagination envelope.
+
+    Behaves exactly like the plain list it replaces; the paginator reads
+    the ``pagination`` attribute instead of intercepting the response
+    through a client-wide event hook.
+    """
+
+    def __init__(self, items: List[Any], pagination: Optional[Dict[str, Any]] = None):
+        super().__init__(items)
+        self.pagination = pagination

--- a/seam/paginator.py
+++ b/seam/paginator.py
@@ -8,9 +8,8 @@ from typing import (
     Optional,
     Tuple,
 )
-from json import JSONDecodeError
-from httpx import Response
 from .client import AsyncSeamHttpClient, SeamHttpClient
+from .exceptions import SeamHttpInvalidResponseError
 from .pagination import Pagination
 
 
@@ -22,14 +21,28 @@ def parse_pagination(pagination: Dict[str, Any]) -> Pagination:
     )
 
 
+def read_pagination(data: Any, request: Callable) -> Pagination:
+    """Read the pagination envelope a paginated route attaches to its result."""
+
+    pagination = getattr(data, "pagination", None)
+
+    if not isinstance(pagination, dict):
+        path = getattr(request, "__seam_path__", "this endpoint")
+        raise SeamHttpInvalidResponseError(
+            path,
+            "pagination",
+            f"got {type(pagination).__name__} instead of a pagination object",
+        )
+
+    return parse_pagination(pagination)
+
+
 class SeamPaginator:
     """
     Handles pagination for API list endpoints.
 
     Iterates through pages of results returned by a callable function.
     """
-
-    _FIRST_PAGE = "FIRST_PAGE"
 
     def __init__(
         self,
@@ -48,19 +61,12 @@ class SeamPaginator:
         self._request = request
         self.client = client
         self._params = params or {}
-        self._pagination_cache: Dict[str, Pagination] = {}
 
     def first_page(self) -> Tuple[List[Any], Pagination | None]:
         """Fetches the first page of results."""
-        self.client.event_hooks["response"].append(
-            lambda response: self._cache_pagination(response, self._FIRST_PAGE)
-        )
         data = self._request(**self._params)
-        self.client.event_hooks["response"].pop()
 
-        pagination = self._pagination_cache.get(self._FIRST_PAGE)
-
-        return data, pagination
+        return data, read_pagination(data, self._request)
 
     def next_page(
         self, next_page_cursor: str, /
@@ -74,15 +80,9 @@ class SeamPaginator:
             "page_cursor": next_page_cursor,
         }
 
-        self.client.event_hooks["response"].append(
-            lambda response: self._cache_pagination(response, next_page_cursor)
-        )
         data = self._request(**params)
-        self.client.event_hooks["response"].pop()
 
-        pagination = self._pagination_cache.get(next_page_cursor)
-
-        return data, pagination
+        return data, read_pagination(data, self._request)
 
     def flatten_to_list(self) -> List[Any]:
         """Fetches all pages and returns all items as a single list."""
@@ -110,18 +110,6 @@ class SeamPaginator:
             if current_items:
                 yield from current_items
 
-    def _cache_pagination(self, response: Response, page_key: str) -> None:
-        """Extracts pagination dict from response, creates Pagination object, and caches it."""
-        try:
-            # httpx response hooks fire before the response body is read.
-            response.read()
-            pagination = response.json().get("pagination", {})
-        except JSONDecodeError:
-            pagination = {}
-
-        if isinstance(pagination, dict):
-            self._pagination_cache[page_key] = parse_pagination(pagination)
-
 
 class AsyncSeamPaginator:
     """
@@ -129,8 +117,6 @@ class AsyncSeamPaginator:
 
     Iterates through pages of results returned by an awaitable function.
     """
-
-    _FIRST_PAGE = "FIRST_PAGE"
 
     def __init__(
         self,
@@ -149,21 +135,12 @@ class AsyncSeamPaginator:
         self._request = request
         self.client = client
         self._params = params or {}
-        self._pagination_cache: Dict[str, Pagination] = {}
 
     async def first_page(self) -> Tuple[List[Any], Pagination | None]:
         """Fetches the first page of results."""
-
-        async def cache_pagination(response: Response) -> None:
-            await self._cache_pagination(response, self._FIRST_PAGE)
-
-        self.client.event_hooks["response"].append(cache_pagination)
         data = await self._request(**self._params)
-        self.client.event_hooks["response"].pop()
 
-        pagination = self._pagination_cache.get(self._FIRST_PAGE)
-
-        return data, pagination
+        return data, read_pagination(data, self._request)
 
     async def next_page(
         self, next_page_cursor: str, /
@@ -177,16 +154,9 @@ class AsyncSeamPaginator:
             "page_cursor": next_page_cursor,
         }
 
-        async def cache_pagination(response: Response) -> None:
-            await self._cache_pagination(response, next_page_cursor)
-
-        self.client.event_hooks["response"].append(cache_pagination)
         data = await self._request(**params)
-        self.client.event_hooks["response"].pop()
 
-        pagination = self._pagination_cache.get(next_page_cursor)
-
-        return data, pagination
+        return data, read_pagination(data, self._request)
 
     async def flatten_to_list(self) -> List[Any]:
         """Fetches all pages and returns all items as a single list."""
@@ -217,15 +187,3 @@ class AsyncSeamPaginator:
             )
             for item in current_items or []:
                 yield item
-
-    async def _cache_pagination(self, response: Response, page_key: str) -> None:
-        """Extracts pagination dict from response, creates Pagination object, and caches it."""
-        try:
-            # httpx response hooks fire before the response body is read.
-            await response.aread()
-            pagination = response.json().get("pagination", {})
-        except JSONDecodeError:
-            pagination = {}
-
-        if isinstance(pagination, dict):
-            self._pagination_cache[page_key] = parse_pagination(pagination)

--- a/seam/routes/access_codes.py
+++ b/seam/routes/access_codes.py
@@ -18,6 +18,7 @@ from .access_codes_unmanaged import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAccessCodes(abc.ABC):
@@ -1140,10 +1141,13 @@ class AccessCodes(AbstractAccessCodes):
 
         res = self.client.get("/access_codes/list", params=params)
 
-        return [
-            AccessCode.from_dict(item)
-            for item in unwrap_list(res, "access_codes", "/access_codes/list")
-        ]
+        return PaginatedList(
+            [
+                AccessCode.from_dict(item)
+                for item in unwrap_list(res, "access_codes", "/access_codes/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",
@@ -1773,10 +1777,13 @@ class AsyncAccessCodes(AbstractAsyncAccessCodes):
 
         res = await self.client.get("/access_codes/list", params=params)
 
-        return [
-            AccessCode.from_dict(item)
-            for item in unwrap_list(res, "access_codes", "/access_codes/list")
-        ]
+        return PaginatedList(
+            [
+                AccessCode.from_dict(item)
+                for item in unwrap_list(res, "access_codes", "/access_codes/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_codes/pull_backup_access_code",

--- a/seam/routes/access_codes_unmanaged.py
+++ b/seam/routes/access_codes_unmanaged.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import UnmanagedAccessCode
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAccessCodesUnmanaged(abc.ABC):
@@ -392,10 +393,15 @@ class AccessCodesUnmanaged(AbstractAccessCodesUnmanaged):
 
         res = self.client.get("/access_codes/unmanaged/list", params=params)
 
-        return [
-            UnmanagedAccessCode.from_dict(item)
-            for item in unwrap_list(res, "access_codes", "/access_codes/unmanaged/list")
-        ]
+        return PaginatedList(
+            [
+                UnmanagedAccessCode.from_dict(item)
+                for item in unwrap_list(
+                    res, "access_codes", "/access_codes/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_codes/unmanaged/update",
@@ -611,10 +617,15 @@ class AsyncAccessCodesUnmanaged(AbstractAsyncAccessCodesUnmanaged):
 
         res = await self.client.get("/access_codes/unmanaged/list", params=params)
 
-        return [
-            UnmanagedAccessCode.from_dict(item)
-            for item in unwrap_list(res, "access_codes", "/access_codes/unmanaged/list")
-        ]
+        return PaginatedList(
+            [
+                UnmanagedAccessCode.from_dict(item)
+                for item in unwrap_list(
+                    res, "access_codes", "/access_codes/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_codes/unmanaged/update",

--- a/seam/routes/access_grants.py
+++ b/seam/routes/access_grants.py
@@ -12,6 +12,7 @@ from .access_grants_unmanaged import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAccessGrants(abc.ABC):
@@ -798,10 +799,13 @@ class AccessGrants(AbstractAccessGrants):
 
         res = self.client.get("/access_grants/list", params=params)
 
-        return [
-            AccessGrant.from_dict(item)
-            for item in unwrap_list(res, "access_grants", "/access_grants/list")
-        ]
+        return PaginatedList(
+            [
+                AccessGrant.from_dict(item)
+                for item in unwrap_list(res, "access_grants", "/access_grants/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_grants/request_access_methods",
@@ -1232,10 +1236,13 @@ class AsyncAccessGrants(AbstractAsyncAccessGrants):
 
         res = await self.client.get("/access_grants/list", params=params)
 
-        return [
-            AccessGrant.from_dict(item)
-            for item in unwrap_list(res, "access_grants", "/access_grants/list")
-        ]
+        return PaginatedList(
+            [
+                AccessGrant.from_dict(item)
+                for item in unwrap_list(res, "access_grants", "/access_grants/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_grants/request_access_methods",

--- a/seam/routes/access_grants_unmanaged.py
+++ b/seam/routes/access_grants_unmanaged.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import UnmanagedAccessGrant
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAccessGrantsUnmanaged(abc.ABC):
@@ -206,12 +207,15 @@ class AccessGrantsUnmanaged(AbstractAccessGrantsUnmanaged):
 
         res = self.client.get("/access_grants/unmanaged/list", params=params)
 
-        return [
-            UnmanagedAccessGrant.from_dict(item)
-            for item in unwrap_list(
-                res, "access_grants", "/access_grants/unmanaged/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                UnmanagedAccessGrant.from_dict(item)
+                for item in unwrap_list(
+                    res, "access_grants", "/access_grants/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_grants/unmanaged/update",
@@ -325,12 +329,15 @@ class AsyncAccessGrantsUnmanaged(AbstractAsyncAccessGrantsUnmanaged):
 
         res = await self.client.get("/access_grants/unmanaged/list", params=params)
 
-        return [
-            UnmanagedAccessGrant.from_dict(item)
-            for item in unwrap_list(
-                res, "access_grants", "/access_grants/unmanaged/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                UnmanagedAccessGrant.from_dict(item)
+                for item in unwrap_list(
+                    res, "access_grants", "/access_grants/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_grants/unmanaged/update",

--- a/seam/routes/access_methods.py
+++ b/seam/routes/access_methods.py
@@ -16,6 +16,7 @@ from ..modules.action_attempts import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAccessMethods(abc.ABC):
@@ -677,10 +678,13 @@ class AccessMethods(AbstractAccessMethods):
 
         res = self.client.get("/access_methods/list", params=params)
 
-        return [
-            AccessMethod.from_dict(item)
-            for item in unwrap_list(res, "access_methods", "/access_methods/list")
-        ]
+        return PaginatedList(
+            [
+                AccessMethod.from_dict(item)
+                for item in unwrap_list(res, "access_methods", "/access_methods/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_methods/unlock_door",
@@ -1038,10 +1042,13 @@ class AsyncAccessMethods(AbstractAsyncAccessMethods):
 
         res = await self.client.get("/access_methods/list", params=params)
 
-        return [
-            AccessMethod.from_dict(item)
-            for item in unwrap_list(res, "access_methods", "/access_methods/list")
-        ]
+        return PaginatedList(
+            [
+                AccessMethod.from_dict(item)
+                for item in unwrap_list(res, "access_methods", "/access_methods/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/access_methods/unlock_door",

--- a/seam/routes/acs_credentials.py
+++ b/seam/routes/acs_credentials.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import AcsCredential, AcsEntrance
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAcsCredentials(abc.ABC):
@@ -565,10 +566,13 @@ class AcsCredentials(AbstractAcsCredentials):
 
         res = self.client.get("/acs/credentials/list", params=params)
 
-        return [
-            AcsCredential.from_dict(item)
-            for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
-        ]
+        return PaginatedList(
+            [
+                AcsCredential.from_dict(item)
+                for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",
@@ -889,10 +893,13 @@ class AsyncAcsCredentials(AbstractAsyncAcsCredentials):
 
         res = await self.client.get("/acs/credentials/list", params=params)
 
-        return [
-            AcsCredential.from_dict(item)
-            for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
-        ]
+        return PaginatedList(
+            [
+                AcsCredential.from_dict(item)
+                for item in unwrap_list(res, "acs_credentials", "/acs/credentials/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/credentials/list_accessible_entrances",

--- a/seam/routes/acs_encoders.py
+++ b/seam/routes/acs_encoders.py
@@ -16,6 +16,7 @@ from ..modules.action_attempts import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAcsEncoders(abc.ABC):
@@ -351,10 +352,13 @@ class AcsEncoders(AbstractAcsEncoders):
 
         res = self.client.get("/acs/encoders/list", params=params)
 
-        return [
-            AcsEncoder.from_dict(item)
-            for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
-        ]
+        return PaginatedList(
+            [
+                AcsEncoder.from_dict(item)
+                for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/encoders/scan_credential",
@@ -576,10 +580,13 @@ class AsyncAcsEncoders(AbstractAsyncAcsEncoders):
 
         res = await self.client.get("/acs/encoders/list", params=params)
 
-        return [
-            AcsEncoder.from_dict(item)
-            for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
-        ]
+        return PaginatedList(
+            [
+                AcsEncoder.from_dict(item)
+                for item in unwrap_list(res, "acs_encoders", "/acs/encoders/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/encoders/scan_credential",

--- a/seam/routes/acs_entrances.py
+++ b/seam/routes/acs_entrances.py
@@ -15,6 +15,7 @@ from ..modules.action_attempts import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAcsEntrances(abc.ABC):
@@ -359,10 +360,13 @@ class AcsEntrances(AbstractAcsEntrances):
 
         res = self.client.get("/acs/entrances/list", params=params)
 
-        return [
-            AcsEntrance.from_dict(item)
-            for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
-        ]
+        return PaginatedList(
+            [
+                AcsEntrance.from_dict(item)
+                for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",
@@ -571,10 +575,13 @@ class AsyncAcsEntrances(AbstractAsyncAcsEntrances):
 
         res = await self.client.get("/acs/entrances/list", params=params)
 
-        return [
-            AcsEntrance.from_dict(item)
-            for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
-        ]
+        return PaginatedList(
+            [
+                AcsEntrance.from_dict(item)
+                for item in unwrap_list(res, "acs_entrances", "/acs/entrances/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/entrances/list_credentials_with_access",

--- a/seam/routes/acs_users.py
+++ b/seam/routes/acs_users.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import AcsUser, AcsEntrance
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractAcsUsers(abc.ABC):
@@ -760,10 +761,13 @@ class AcsUsers(AbstractAcsUsers):
 
         res = self.client.get("/acs/users/list", params=params)
 
-        return [
-            AcsUser.from_dict(item)
-            for item in unwrap_list(res, "acs_users", "/acs/users/list")
-        ]
+        return PaginatedList(
+            [
+                AcsUser.from_dict(item)
+                for item in unwrap_list(res, "acs_users", "/acs/users/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",
@@ -1336,10 +1340,13 @@ class AsyncAcsUsers(AbstractAsyncAcsUsers):
 
         res = await self.client.get("/acs/users/list", params=params)
 
-        return [
-            AcsUser.from_dict(item)
-            for item in unwrap_list(res, "acs_users", "/acs/users/list")
-        ]
+        return PaginatedList(
+            [
+                AcsUser.from_dict(item)
+                for item in unwrap_list(res, "acs_users", "/acs/users/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/acs/users/list_accessible_entrances",

--- a/seam/routes/action_attempts.py
+++ b/seam/routes/action_attempts.py
@@ -10,6 +10,7 @@ from ..modules.action_attempts import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractActionAttempts(abc.ABC):
@@ -175,10 +176,13 @@ class ActionAttempts(AbstractActionAttempts):
 
         res = self.client.get("/action_attempts/list", params=params)
 
-        return [
-            action_attempt_from_dict(item)
-            for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
-        ]
+        return PaginatedList(
+            [
+                action_attempt_from_dict(item)
+                for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
 
 class AsyncActionAttempts(AbstractAsyncActionAttempts):
@@ -262,7 +266,10 @@ class AsyncActionAttempts(AbstractAsyncActionAttempts):
 
         res = await self.client.get("/action_attempts/list", params=params)
 
-        return [
-            action_attempt_from_dict(item)
-            for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
-        ]
+        return PaginatedList(
+            [
+                action_attempt_from_dict(item)
+                for item in unwrap_list(res, "action_attempts", "/action_attempts/list")
+            ],
+            pagination=res.get("pagination"),
+        )

--- a/seam/routes/connect_webviews.py
+++ b/seam/routes/connect_webviews.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import ConnectWebview
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractConnectWebviews(abc.ABC):
@@ -650,10 +651,15 @@ class ConnectWebviews(AbstractConnectWebviews):
 
         res = self.client.get("/connect_webviews/list", params=params)
 
-        return [
-            ConnectWebview.from_dict(item)
-            for item in unwrap_list(res, "connect_webviews", "/connect_webviews/list")
-        ]
+        return PaginatedList(
+            [
+                ConnectWebview.from_dict(item)
+                for item in unwrap_list(
+                    res, "connect_webviews", "/connect_webviews/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
 
 class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
@@ -922,7 +928,12 @@ class AsyncConnectWebviews(AbstractAsyncConnectWebviews):
 
         res = await self.client.get("/connect_webviews/list", params=params)
 
-        return [
-            ConnectWebview.from_dict(item)
-            for item in unwrap_list(res, "connect_webviews", "/connect_webviews/list")
-        ]
+        return PaginatedList(
+            [
+                ConnectWebview.from_dict(item)
+                for item in unwrap_list(
+                    res, "connect_webviews", "/connect_webviews/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )

--- a/seam/routes/connected_accounts.py
+++ b/seam/routes/connected_accounts.py
@@ -12,6 +12,7 @@ from .connected_accounts_simulate import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractConnectedAccounts(abc.ABC):
@@ -357,12 +358,15 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
         res = self.client.get("/connected_accounts/list", params=params)
 
-        return [
-            ConnectedAccount.from_dict(item)
-            for item in unwrap_list(
-                res, "connected_accounts", "/connected_accounts/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                ConnectedAccount.from_dict(item)
+                for item in unwrap_list(
+                    res, "connected_accounts", "/connected_accounts/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/connected_accounts/sync",
@@ -571,12 +575,15 @@ class AsyncConnectedAccounts(AbstractAsyncConnectedAccounts):
 
         res = await self.client.get("/connected_accounts/list", params=params)
 
-        return [
-            ConnectedAccount.from_dict(item)
-            for item in unwrap_list(
-                res, "connected_accounts", "/connected_accounts/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                ConnectedAccount.from_dict(item)
+                for item in unwrap_list(
+                    res, "connected_accounts", "/connected_accounts/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/connected_accounts/sync",

--- a/seam/routes/devices.py
+++ b/seam/routes/devices.py
@@ -18,6 +18,7 @@ from .devices_unmanaged import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractDevices(abc.ABC):
@@ -921,10 +922,13 @@ class Devices(AbstractDevices):
 
         res = self.client.get("/devices/list", params=params)
 
-        return [
-            Device.from_dict(item)
-            for item in unwrap_list(res, "devices", "/devices/list")
-        ]
+        return PaginatedList(
+            [
+                Device.from_dict(item)
+                for item in unwrap_list(res, "devices", "/devices/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/devices/list_device_providers",
@@ -1339,10 +1343,13 @@ class AsyncDevices(AbstractAsyncDevices):
 
         res = await self.client.get("/devices/list", params=params)
 
-        return [
-            Device.from_dict(item)
-            for item in unwrap_list(res, "devices", "/devices/list")
-        ]
+        return PaginatedList(
+            [
+                Device.from_dict(item)
+                for item in unwrap_list(res, "devices", "/devices/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/devices/list_device_providers",

--- a/seam/routes/devices_unmanaged.py
+++ b/seam/routes/devices_unmanaged.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import UnmanagedDevice
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractDevicesUnmanaged(abc.ABC):
@@ -767,10 +768,13 @@ class DevicesUnmanaged(AbstractDevicesUnmanaged):
 
         res = self.client.get("/devices/unmanaged/list", params=params)
 
-        return [
-            UnmanagedDevice.from_dict(item)
-            for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
-        ]
+        return PaginatedList(
+            [
+                UnmanagedDevice.from_dict(item)
+                for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/devices/unmanaged/update",
@@ -1089,10 +1093,13 @@ class AsyncDevicesUnmanaged(AbstractAsyncDevicesUnmanaged):
 
         res = await self.client.get("/devices/unmanaged/list", params=params)
 
-        return [
-            UnmanagedDevice.from_dict(item)
-            for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
-        ]
+        return PaginatedList(
+            [
+                UnmanagedDevice.from_dict(item)
+                for item in unwrap_list(res, "devices", "/devices/unmanaged/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/devices/unmanaged/update",

--- a/seam/routes/spaces.py
+++ b/seam/routes/spaces.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import Space, Batch
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractSpaces(abc.ABC):
@@ -747,9 +748,13 @@ class Spaces(AbstractSpaces):
 
         res = self.client.get("/spaces/list", params=params)
 
-        return [
-            Space.from_dict(item) for item in unwrap_list(res, "spaces", "/spaces/list")
-        ]
+        return PaginatedList(
+            [
+                Space.from_dict(item)
+                for item in unwrap_list(res, "spaces", "/spaces/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",
@@ -1175,9 +1180,13 @@ class AsyncSpaces(AbstractAsyncSpaces):
 
         res = await self.client.get("/spaces/list", params=params)
 
-        return [
-            Space.from_dict(item) for item in unwrap_list(res, "spaces", "/spaces/list")
-        ]
+        return PaginatedList(
+            [
+                Space.from_dict(item)
+                for item in unwrap_list(res, "spaces", "/spaces/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/spaces/remove_acs_entrances",

--- a/seam/routes/user_identities.py
+++ b/seam/routes/user_identities.py
@@ -19,6 +19,7 @@ from .user_identities_unmanaged import (
 )
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractUserIdentities(abc.ABC):
@@ -783,10 +784,13 @@ class UserIdentities(AbstractUserIdentities):
 
         res = self.client.get("/user_identities/list", params=params)
 
-        return [
-            UserIdentity.from_dict(item)
-            for item in unwrap_list(res, "user_identities", "/user_identities/list")
-        ]
+        return PaginatedList(
+            [
+                UserIdentity.from_dict(item)
+                for item in unwrap_list(res, "user_identities", "/user_identities/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",
@@ -1312,10 +1316,13 @@ class AsyncUserIdentities(AbstractAsyncUserIdentities):
 
         res = await self.client.get("/user_identities/list", params=params)
 
-        return [
-            UserIdentity.from_dict(item)
-            for item in unwrap_list(res, "user_identities", "/user_identities/list")
-        ]
+        return PaginatedList(
+            [
+                UserIdentity.from_dict(item)
+                for item in unwrap_list(res, "user_identities", "/user_identities/list")
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/user_identities/list_accessible_devices",

--- a/seam/routes/user_identities_unmanaged.py
+++ b/seam/routes/user_identities_unmanaged.py
@@ -6,6 +6,7 @@ from ..null import Null
 from ..resources import UnmanagedUserIdentity
 from ..response import unwrap
 from ..response import unwrap_list
+from ..pagination import PaginatedList
 
 
 class AbstractUserIdentitiesUnmanaged(abc.ABC):
@@ -180,12 +181,15 @@ class UserIdentitiesUnmanaged(AbstractUserIdentitiesUnmanaged):
 
         res = self.client.get("/user_identities/unmanaged/list", params=params)
 
-        return [
-            UnmanagedUserIdentity.from_dict(item)
-            for item in unwrap_list(
-                res, "user_identities", "/user_identities/unmanaged/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                UnmanagedUserIdentity.from_dict(item)
+                for item in unwrap_list(
+                    res, "user_identities", "/user_identities/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/user_identities/unmanaged/update",
@@ -287,12 +291,15 @@ class AsyncUserIdentitiesUnmanaged(AbstractAsyncUserIdentitiesUnmanaged):
 
         res = await self.client.get("/user_identities/unmanaged/list", params=params)
 
-        return [
-            UnmanagedUserIdentity.from_dict(item)
-            for item in unwrap_list(
-                res, "user_identities", "/user_identities/unmanaged/list"
-            )
-        ]
+        return PaginatedList(
+            [
+                UnmanagedUserIdentity.from_dict(item)
+                for item in unwrap_list(
+                    res, "user_identities", "/user_identities/unmanaged/list"
+                )
+            ],
+            pagination=res.get("pagination"),
+        )
 
     @route_metadata(
         path="/user_identities/unmanaged/update",

--- a/test/paginator_isolation_test.py
+++ b/test/paginator_isolation_test.py
@@ -1,0 +1,94 @@
+import asyncio
+
+import pytest
+
+from seam import AsyncSeam, Seam, SeamHttpApiError, SeamHttpInvalidResponseError
+from seam.pagination import PaginatedList
+
+
+def test_paginated_routes_return_a_plain_list_with_the_envelope(seam: Seam):
+    connected_accounts = seam.connected_accounts.list()
+
+    assert isinstance(connected_accounts, list)
+    assert isinstance(connected_accounts, PaginatedList)
+    assert isinstance(connected_accounts.pagination, dict)
+
+
+def test_paginator_leaves_no_hooks_on_the_client(seam: Seam):
+    paginator = seam.create_paginator(seam.connected_accounts.list, {"limit": 1})
+    paginator.flatten_to_list()
+
+    assert len(seam.client.event_hooks["response"]) == 0
+
+
+def test_a_failed_page_request_leaves_no_hooks_on_the_client(recording_server):
+    with recording_server(
+        [(500, {"error": {"type": "internal_error", "message": "Down"}})]
+    ) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+        paginator = seam.create_paginator(seam.devices.list)
+
+        with pytest.raises(SeamHttpApiError):
+            paginator.first_page()
+
+        assert len(seam.client.event_hooks["response"]) == 0
+
+
+def test_a_missing_pagination_envelope_raises(recording_server):
+    with recording_server([(200, {"devices": []})]) as (endpoint, _):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+        paginator = seam.create_paginator(seam.devices.list)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match="Seam returned an invalid response for /devices/list: "
+            'expected "pagination", got NoneType instead of a pagination object',
+        ):
+            paginator.first_page()
+
+
+def test_a_non_object_pagination_envelope_raises(recording_server):
+    with recording_server([(200, {"devices": [], "pagination": "bogus"})]) as (
+        endpoint,
+        _,
+    ):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+        paginator = seam.create_paginator(seam.devices.list)
+
+        with pytest.raises(
+            SeamHttpInvalidResponseError,
+            match='expected "pagination", got str instead of a pagination object',
+        ):
+            paginator.first_page()
+
+
+async def test_concurrent_paginators_do_not_interfere(async_seam: AsyncSeam):
+    all_connected_accounts = await async_seam.connected_accounts.list()
+
+    first = async_seam.create_paginator(
+        async_seam.connected_accounts.list, {"limit": 1}
+    )
+    second = async_seam.create_paginator(
+        async_seam.connected_accounts.list, {"limit": 2}
+    )
+
+    first_items, second_items = await asyncio.gather(
+        first.flatten_to_list(), second.flatten_to_list()
+    )
+
+    assert len(first_items) == len(all_connected_accounts)
+    assert len(second_items) == len(all_connected_accounts)
+    assert len(async_seam.client.event_hooks["response"]) == 0
+
+
+async def test_a_missing_pagination_envelope_raises_async(recording_server):
+    with recording_server([(200, {"devices": []})]) as (endpoint, _):
+        async with AsyncSeam(api_key="seam_apikey_token", endpoint=endpoint) as seam:
+            paginator = seam.create_paginator(seam.devices.list)
+
+            with pytest.raises(
+                SeamHttpInvalidResponseError,
+                match='expected "pagination", got NoneType instead of a '
+                "pagination object",
+            ):
+                await paginator.first_page()


### PR DESCRIPTION
## What

The paginator captured the pagination envelope by appending a response hook to the shared client's `event_hooks`, making the request, then calling `.pop()` (SDK audit finding H4). That side-channel had four defects, all reproduced by the audit:

- No `try/finally`: any failed page request (4xx/5xx, timeout) leaked the hook onto the client **permanently** — every later response on that `Seam` instance was force-read and JSON-parsed by a dead paginator's hook.
- `.pop()` removes the *last* hook, not the paginator's own: two interleaved paginators cross-deleted each other's hooks. The async client made this the default failure mode — `asyncio.gather` over two paginators is normal usage.
- A non-dict `pagination` value silently truncated `flatten()` to one page with no error.
- The cursor-keyed `_pagination_cache` grew unbounded and used a `"FIRST_PAGE"` string sentinel that could collide with a real cursor.

The redesign removes the side-channel entirely:

- Paginated routes now return a `PaginatedList` — a `list` subclass carrying the response's `pagination` envelope as an attribute. Callers of `*.list()` see no difference (`isinstance(x, list)`, iteration, equality all unchanged). This is a codegen template change gated on `hasPagination`, so it lands at every paginated route at once, and any future request-level behavior reaches paginated requests for free (the drift-resistance property from the JS fix wave).
- The paginator reads `data.pagination` directly: no hooks, no cache, no sentinel, nothing shared. A missing or non-object envelope raises `SeamHttpInvalidResponseError` (from #638) instead of silently truncating.
- The paginator's `client` constructor parameter is retained for signature compatibility but no longer used.

Also bumps `@seamapi/fake-seam-connect` 2.0.5 → 2.0.6, which fixed `/access_codes/list` returning no pagination envelope (the same upstream fix the JS wave landed as fake-seam-connect #283) — the new envelope check caught it immediately.

**Stacked on [#639](https://github.com/seamapi/python/pull/639)**; diff shrinks as the stack merges.

## Testing

New `test/paginator_isolation_test.py`: two async paginators under `asyncio.gather` each see their own pagination with zero hooks on the client; a failed page request leaves no hooks; missing/non-object pagination envelopes raise with pinned messages (sync + async); paginated routes still return a plain `list` carrying the envelope.

Revert check: with the old paginator restored, the tests fail with the audit's exact symptoms — one leaked hook after a failed request (`assert 1 == 0` with the lambda visible), interfering concurrent paginators, and `DID NOT RAISE` on the truncation case.

Full suite: 232 passed; mypy, pylint (10.00), black clean; regeneration drift-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_