### PR TITLE
fix: Make the workspace-less abstract clients abstract

### DIFF
--- a/seam/models.py
+++ b/seam/models.py
@@ -120,7 +120,7 @@ class AbstractAsyncSeamWithoutWorkspaceWorkspaces(abc.ABC):
         raise NotImplementedError()
 
 
-class AbstractSeamWithoutWorkspace:
+class AbstractSeamWithoutWorkspace(abc.ABC):
     wait_for_action_attempt: Optional[Union[bool, Dict[str, float]]]
 
     @abc.abstractmethod
@@ -145,7 +145,7 @@ class AbstractSeamWithoutWorkspace:
         raise NotImplementedError
 
 
-class AbstractAsyncSeamWithoutWorkspace:
+class AbstractAsyncSeamWithoutWorkspace(abc.ABC):
     wait_for_action_attempt: Optional[Union[bool, Dict[str, float]]]
 
     @abc.abstractmethod

--- a/test/abstract_models_test.py
+++ b/test/abstract_models_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from seam.models import (
+    AbstractAsyncSeamWithoutWorkspace,
+    AbstractSeamWithoutWorkspace,
+)
+
+
+def test_abstract_seam_without_workspace_cannot_be_instantiated():
+    with pytest.raises(TypeError, match="abstract"):
+        # pylint: disable-next=abstract-class-instantiated
+        AbstractSeamWithoutWorkspace("seam_at_token")  # type: ignore[abstract]
+
+
+def test_abstract_async_seam_without_workspace_cannot_be_instantiated():
+    with pytest.raises(TypeError, match="abstract"):
+        # pylint: disable-next=abstract-class-instantiated
+        AbstractAsyncSeamWithoutWorkspace("seam_at_token")  # type: ignore[abstract]


### PR DESCRIPTION
## What

`AbstractSeamWithoutWorkspace` and `AbstractAsyncSeamWithoutWorkspace` used `@abc.abstractmethod` without an `ABCMeta` metaclass, so the decorator set `__isabstractmethod__` and nothing ever read it — both classes were directly instantiable (SDK audit finding L5b). Every other abstract base in the SDK (`AbstractSeam`, `AbstractSeamHttpClient`, the workspaces abstracts) already inherits `abc.ABC`; these two were the odd ones out.

Both now inherit `abc.ABC`, making instantiation a `TypeError` like their siblings. `SeamWithoutWorkspace` / `AsyncSeamWithoutWorkspace` subclass them with concrete implementations, so nothing else changes.

## Testing

New `test/abstract_models_test.py` asserts direct instantiation of both classes raises `TypeError`. Revert check: with `seam/models.py` reverted to main, both tests fail (the classes instantiate silently). Full suite: 187 passed; mypy, pylint (10.00), black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_