### PR TITLE
fix: Replace NULL sentinels in form data and tolerate malformed validation errors

### DIFF
--- a/seam/client.py
+++ b/seam/client.py
@@ -158,6 +158,9 @@ class SeamHttpClient(httpx.Client, SeamHttpResponseHandler, AbstractSeamHttpClie
         if "json" in kwargs:
             kwargs["json"] = replace_null(kwargs["json"])
 
+        if isinstance(kwargs.get("data"), Mapping):
+            kwargs["data"] = replace_null(kwargs["data"])
+
         response = super().request(method, url, *args, **kwargs)
 
         return self._handle_response(response)
@@ -218,6 +221,9 @@ class AsyncSeamHttpClient(
 
         if "json" in kwargs:
             kwargs["json"] = replace_null(kwargs["json"])
+
+        if isinstance(kwargs.get("data"), Mapping):
+            kwargs["data"] = replace_null(kwargs["data"])
 
         response = await super().request(method, url, *args, **kwargs)
 

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -99,7 +99,13 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
 
         super().__init__(error, status_code, request_id)
         self.code = "invalid_input"
-        self._validation_errors = error.get("validation_errors") or {}
+        validation_errors = error.get("validation_errors")
+        # The envelope shape is server-controlled: anything but the expected
+        # object of objects reads as no validation details rather than
+        # raising from inside the error accessors.
+        self._validation_errors = (
+            validation_errors if isinstance(validation_errors, dict) else {}
+        )
 
     @property
     def validation_errors(self) -> List[SeamValidationError]:
@@ -123,7 +129,14 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
         :rtype: List[str]
         """
 
-        return self._validation_errors.get(param_name, {}).get("_errors", [])
+        messages = self._validation_errors.get(param_name)
+
+        if not isinstance(messages, dict):
+            return []
+
+        errors = messages.get("_errors", [])
+
+        return errors if isinstance(errors, list) else []
 
 
 # Action Attempt

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -100,9 +100,6 @@ class SeamHttpInvalidInputError(SeamHttpApiError):
         super().__init__(error, status_code, request_id)
         self.code = "invalid_input"
         validation_errors = error.get("validation_errors")
-        # The envelope shape is server-controlled: anything but the expected
-        # object of objects reads as no validation details rather than
-        # raising from inside the error accessors.
         self._validation_errors = (
             validation_errors if isinstance(validation_errors, dict) else {}
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -94,7 +94,7 @@ def recording_server(responses):
                     "path": path,
                     "query": query,
                     "headers": {k.lower(): v for k, v in self.headers.items()},
-                    "body": json.loads(raw_body) if raw_body else None,
+                    "body": parse_body(raw_body),
                 }
             )
 
@@ -138,6 +138,17 @@ def recording_server(responses):
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+
+
+def parse_body(raw_body):
+    if not raw_body:
+        return None
+
+    try:
+        return json.loads(raw_body)
+    except json.JSONDecodeError:
+        # Form-encoded bodies are recorded as text.
+        return raw_body.decode()
 
 
 @contextmanager

--- a/test/null_data_test.py
+++ b/test/null_data_test.py
@@ -1,0 +1,60 @@
+from seam import NULL, Seam
+from seam.exceptions import SeamHttpInvalidInputError
+
+
+def test_null_sentinel_in_form_data_is_replaced(recording_server):
+    with recording_server([(200, {"ok": True})]) as (endpoint, requests):
+        seam = Seam.from_api_key("seam_apikey_token", endpoint=endpoint)
+
+        seam.client.post("/example", data={"name": NULL, "kept": "value"})
+
+        # The sentinel form-encodes as an empty value, never the string NULL.
+        assert requests[0]["body"] == "name=&kept=value"
+
+
+def make_invalid_input_error(validation_errors):
+    return SeamHttpInvalidInputError(
+        {
+            "type": "invalid_input",
+            "message": "Invalid input",
+            "validation_errors": validation_errors,
+        },
+        400,
+        "request-id",
+    )
+
+
+def test_validation_errors_tolerates_a_list_envelope():
+    error = make_invalid_input_error(["not", "a", "dict"])
+
+    assert error.validation_errors == []
+    assert error.get_validation_error_messages("device_ids") == []
+
+
+def test_validation_errors_tolerates_a_string_envelope():
+    error = make_invalid_input_error("bad input")
+
+    assert error.validation_errors == []
+    assert error.get_validation_error_messages("device_ids") == []
+
+
+def test_validation_errors_tolerates_a_non_dict_parameter_value():
+    error = make_invalid_input_error(
+        {
+            "device_ids": ["bad"],
+            "name": {"_errors": ["Required"]},
+        }
+    )
+
+    assert error.get_validation_error_messages("device_ids") == []
+    assert error.get_validation_error_messages("name") == ["Required"]
+
+    validation_errors = error.validation_errors
+    assert len(validation_errors) == 2
+    assert {e.parameter_name for e in validation_errors} == {"device_ids", "name"}
+
+
+def test_validation_errors_tolerates_non_list_errors():
+    error = make_invalid_input_error({"name": {"_errors": "Required"}})
+
+    assert error.get_validation_error_messages("name") == []


### PR DESCRIPTION
## What

Two small hardening fixes from the SDK audit's L5 grab-bag:

**`NULL` in form data (L5c).** The client's `request` override applied `replace_null` to `json=` bodies and search params but not to `data=` — so the documented `NULL` sentinel form-encoded via `str()` as the literal string `"NULL"`. No generated route uses `data=`, but it is part of the documented `seam.client.post(...)` escape hatch. Mapping-shaped `data=` now gets the same `replace_null` pass in both clients (`name=NULL&kept=value` → `name=&kept=value`).

**Malformed `validation_errors` shapes (L5d).** `SeamHttpInvalidInputError` trusted the server's `validation_errors` envelope: a list/string envelope, or a parameter entry that isn't a dict, raised `AttributeError` from inside the accessors — and the `validation_errors` property added in #631 walks *every* key, so a single oddly-shaped entry blew up the whole accessor. Both accessors now degrade to "no validation details" (`[]`) for anything but the expected object-of-objects shape, while well-formed entries next to malformed ones still surface.

Also teaches the test suite's recording server to record form-encoded bodies as text instead of failing to JSON-parse them.

## Testing

New `test/null_data_test.py`: wire assertion that the sentinel form-encodes as an empty value; list/string envelopes and non-dict/non-list parameter values return `[]` without raising, with well-formed siblings intact.

Revert check: with `seam/client.py` and `seam/exceptions.py` reverted, the tests fail with the audit's symptoms — `name=NULL&kept=value` on the wire and `AttributeError: 'list' object has no attribute 'get'`.

Full suite: 190 passed; mypy, pylint (10.00), black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_