### PR TITLE
fix: Use the generated pagination dataclass in the paginator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ required-version = ">=0.12.0,<0.13.0"
 
 [tool.uv.build-backend]
 module-root = ""
-source-exclude = ["**/*_test.py"]
-wheel-exclude = ["**/*_test.py"]
+source-exclude = ["**/*_test.py", "**/__pycache__"]
+wheel-exclude = ["**/*_test.py", "**/__pycache__"]
 
 [tool.black]
 target-version = ["py311"]

--- a/seam/pagination.py
+++ b/seam/pagination.py
@@ -1,16 +1,8 @@
 from typing import Any, Dict, List, Optional
 
+from .resources.pagination import Pagination
 
-class Pagination:
-    def __init__(
-        self,
-        has_next_page: bool,
-        next_page_cursor: str | None,
-        next_page_url: str | None,
-    ):
-        self.has_next_page = has_next_page
-        self.next_page_cursor = next_page_cursor
-        self.next_page_url = next_page_url
+__all__ = ["PaginatedList", "Pagination"]
 
 
 class PaginatedList(List[Any]):

--- a/test/paginator_test.py
+++ b/test/paginator_test.py
@@ -1,7 +1,9 @@
 import pytest
 
 from seam import Seam
+from seam.pagination import Pagination
 from seam.paginator import SeamPaginator
+from seam.resources import Pagination as ResourcePagination
 
 
 def test_create_paginator_returns_a_paginator(seam: Seam):
@@ -82,3 +84,13 @@ def test_paginator_flatten(seam: Seam):
 
     assert len(collected_accounts) > 1
     assert len(collected_accounts) == len(all_connected_accounts)
+
+
+def test_paginator_returns_the_generated_pagination_resource(seam: Seam):
+    assert Pagination is ResourcePagination
+
+    paginator = seam.create_paginator(seam.connected_accounts.list, {"limit": 2})
+    _, pagination = paginator.first_page()
+
+    assert isinstance(pagination, ResourcePagination)
+    assert pagination.has_next_page is True


### PR DESCRIPTION
## What

Two `Pagination` classes existed: a hand-written one in `seam/pagination.py` that the paginator used, and the generated `@dataclass` in `seam/resources/pagination.py` that was exported from `seam.resources` but never constructed, imported, or tested anywhere — a dead class shadowing a live one of the same name, and the two disagreed on the null case (SDK audit finding L5a).

- `seam/paginator.py` now hydrates the **generated** dataclass (via the existing `parse_pagination`, which supplies the correct `has_next_page=False` default), so the exported resource class is the one callers actually receive and the hand-written duplicate is gone. `seam/pagination.py` keeps `PaginatedList` and re-exports `Pagination` so no import path breaks.
- Folds in the audit's L9 remnant: the wheel/sdist excludes gain `**/__pycache__` alongside `**/*_test.py` (cheap insurance for a dirty local build; verified the built wheel is clean).

**Stacked on [#641](https://github.com/seamapi/python/pull/641)**; diff shrinks as the stack merges. Lowest-priority PR of the audit wave — fine to take last.

## Testing

New test pins that `seam.pagination.Pagination` *is* `seam.resources.Pagination` and that `first_page()` returns an instance of it with correct fields. Wheel contents verified free of `__pycache__` and `*_test.py`. Full suite: 236 passed; mypy, pylint (10.00), black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1RzepycXEYA3LStfjt8cY)_