### PR TITLE
feat: Improve API response parsing resilience to unknown fields

### DIFF
--- a/codegen/layouts/partials/resource-dataclass.hbs
+++ b/codegen/layouts/partials/resource-dataclass.hbs
@@ -31,8 +31,10 @@
 {{#unless properties}}
 {{memberIndent}}    # pylint: disable=unused-argument
 {{/unless}}
+{{memberIndent}}    if not isinstance(d, dict):
+{{memberIndent}}        d = {}
 {{memberIndent}}    return cls(
 {{#each properties}}
-{{../memberIndent}}        {{pythonIdentifier name}}={{#if isRequiredObject}}cls.{{nestedClassName}}.from_dict(d.get("{{name}}") or {}){{else}}{{#if isObject}}cls.{{nestedClassName}}.from_dict(d.get("{{name}}")) if d.get("{{name}}") is not None else None{{else}}{{#if isDiscriminatedObjectList}}[_from_discriminated_dict(i, cls._{{nestedClassName}}Variants, "{{discriminator}}") for i in d.get("{{name}}") or []]{{else}}{{#if isObjectList}}[cls.{{nestedClassName}}.from_dict(i) for i in d.get("{{name}}") or []]{{else}}{{#if isDictParam}}DeepAttrDict({{/if}}d.get("{{name}}", None){{#if isDictParam}}){{/if}}{{/if}}{{/if}}{{/if}}{{/if}},
+{{../memberIndent}}        {{pythonIdentifier name}}={{#if isRequiredObject}}_required_object_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isObject}}_object_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isDiscriminatedObjectList}}_discriminated_list_from_dict(d.get("{{name}}"), cls._{{nestedClassName}}Variants, "{{discriminator}}"){{else}}{{#if isObjectList}}_object_list_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isDictParam}}_record_from_dict({{/if}}d.get("{{name}}", None){{#if isDictParam}}){{/if}}{{/if}}{{/if}}{{/if}}{{/if}},
 {{/each}}
 {{memberIndent}}    )

--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -1,16 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, {{#if union.secondaryDiscriminator}}Tuple, {{/if}}Union{{#if union}}, cast{{/if}}
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-{{#if hasDiscriminatedLists}}
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
-{{/if}}
 
 {{#each classes}}
 {{> resource-dataclass}}
@@ -36,11 +34,28 @@ def _from_discriminated_dict(
 def {{union.fromDictName}}(d: Any) -> {{union.className}}:
     """Deserialize a known {{union.discriminator}}{{#if union.secondaryDiscriminator}} and {{union.secondaryDiscriminator}}{{/if}} variant.
 
-    Unknown discriminator values return ``DeepAttrDict`` so payloads from a
-    newer API remain readable. The static return type covers known variants.
+    An unrecognized discriminator, or a known one whose payload does not
+    convert, returns ``DeepAttrDict`` so payloads from a newer API remain
+    readable. The static return type covers known variants.
     """
-    variant = {{union.variantsName}}.get({{#if union.secondaryDiscriminator}}(d.get("{{union.discriminator}}"), d.get("{{union.secondaryDiscriminator}}")){{else}}d.get("{{union.discriminator}}"){{/if}})
+    if not isinstance(d, dict):
+        return cast({{union.className}}, DeepAttrDict(d) if isinstance(d, dict) else d)
+{{#if union.secondaryDiscriminator}}
+    key = (d.get("{{union.discriminator}}"), d.get("{{union.secondaryDiscriminator}}"))
+    variant = (
+        {{union.variantsName}}.get(cast(Tuple[str, str], key))
+        if isinstance(key[0], str) and isinstance(key[1], str)
+        else None
+    )
+{{else}}
+    key = d.get("{{union.discriminator}}")
+    variant = {{union.variantsName}}.get(key) if isinstance(key, str) else None
+{{/if}}
     if variant is None:
         return cast({{union.className}}, DeepAttrDict(d))
-    return variant.from_dict(d)
+    try:
+        return variant.from_dict(d)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # A known discriminator whose payload does not convert is still readable.
+        return cast({{union.className}}, DeepAttrDict(d))
 {{/if}}

--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -56,6 +56,5 @@ def {{union.fromDictName}}(d: Any) -> {{union.className}}:
     try:
         return variant.from_dict(d)
     except Exception:  # pylint: disable=broad-exception-caught
-        # A known discriminator whose payload does not convert is still readable.
         return cast({{union.className}}, DeepAttrDict(d))
 {{/if}}

--- a/seam/__init__.py
+++ b/seam/__init__.py
@@ -16,7 +16,9 @@ from .exceptions import (
     SeamActionAttemptError,
     SeamActionAttemptFailedError,
     SeamActionAttemptTimeoutError,
+    SeamActionAttemptUnknownStatusError,
 )
+from .deep_attr_dict import DeepAttrDict
 from .seam_webhook import SeamWebhook
 from svix.webhooks import WebhookVerificationError as SeamWebhookVerificationError
 from .null import NULL, Null

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -260,11 +260,8 @@ class SeamActionAttemptUnknownStatusError(SeamActionAttemptError):
     """
     Exception raised when an action attempt reports a status this SDK does not know.
 
-    Seam adds action attempt statuses over time. Waiting for an attempt promises to
-    return a succeeded attempt or raise, and an unrecognized status supports neither
-    conclusion: reporting success would claim the action completed when the SDK
-    cannot tell, and polling on would block until the timeout and then report a
-    misleading timeout. Read ``action_attempt`` to inspect the status directly.
+    Waiting promises to return a succeeded attempt or raise, and an unrecognized
+    status supports neither. Read ``action_attempt`` to inspect it directly.
 
     :ivar name: Name of the exception class
     :vartype name: str

--- a/seam/exceptions.py
+++ b/seam/exceptions.py
@@ -254,3 +254,36 @@ class SeamActionAttemptTimeoutError(SeamActionAttemptError):
         message = f"Timed out waiting for action attempt after {timeout}s"
         super().__init__(message, action_attempt)
         self.name = self.__class__.__name__
+
+
+class SeamActionAttemptUnknownStatusError(SeamActionAttemptError):
+    """
+    Exception raised when an action attempt reports a status this SDK does not know.
+
+    Seam adds action attempt statuses over time. Waiting for an attempt promises to
+    return a succeeded attempt or raise, and an unrecognized status supports neither
+    conclusion: reporting success would claim the action completed when the SDK
+    cannot tell, and polling on would block until the timeout and then report a
+    misleading timeout. Read ``action_attempt`` to inspect the status directly.
+
+    :ivar name: Name of the exception class
+    :vartype name: str
+    :ivar status: The unrecognized status reported by the API
+    :vartype status: str
+    """
+
+    def __init__(self, action_attempt: ActionAttempt, status: str):
+        """
+        :param action_attempt: The ActionAttempt object carrying the unknown status
+        :type action_attempt: ActionAttempt
+        :param status: The unrecognized status reported by the API
+        :type status: str
+        """
+
+        message = (
+            f'Action attempt reported an unknown status "{status}". '
+            "This SDK version may predate it; upgrade or read the action attempt directly."
+        )
+        super().__init__(message, action_attempt)
+        self.name = self.__class__.__name__
+        self.status = status

--- a/seam/modules/action_attempts.py
+++ b/seam/modules/action_attempts.py
@@ -1,17 +1,37 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, cast
 import asyncio
 import time
 
 from ..client import AsyncSeamHttpClient, SeamHttpClient
-from ..exceptions import SeamActionAttemptFailedError, SeamActionAttemptTimeoutError
+from ..exceptions import (
+    SeamActionAttemptFailedError,
+    SeamActionAttemptTimeoutError,
+    SeamActionAttemptUnknownStatusError,
+)
 from ..options import SeamInvalidOptionsError
-from ..resources import ActionAttempt, SuccessActionAttempt, action_attempt_from_dict
+from ..resources import (
+    ActionAttempt,
+    ErrorActionAttempt,
+    PendingActionAttempt,
+    SuccessActionAttempt,
+    action_attempt_from_dict,
+)
 from ..response import unwrap
 
 TIMEOUT = 5.0
 POLLING_INTERVAL = 0.5
 
 WAIT_FOR_ACTION_ATTEMPT_OPTION_KEYS = ("timeout", "polling_interval")
+
+
+def _status_of(action_attempt: ActionAttempt) -> Optional[str]:
+    """Read the status without assuming the attempt carries one.
+
+    An attempt from a newer API deserializes to a DeepAttrDict, where a missing
+    key raises rather than reading as None.
+    """
+
+    return getattr(action_attempt, "status", None)
 
 
 def validate_wait_for_action_attempt(
@@ -93,20 +113,28 @@ def poll_until_ready(
     if action_attempt is None:
         action_attempt = get_action_attempt(client, action_attempt_id)
 
-    while action_attempt.status == "pending":
+    while _status_of(action_attempt) == "pending":
         remaining = deadline - time.monotonic()
 
         if remaining <= 0:
-            raise SeamActionAttemptTimeoutError(action_attempt, timeout)
+            raise SeamActionAttemptTimeoutError(
+                cast(PendingActionAttempt, action_attempt), timeout
+            )
 
         time.sleep(min(polling_interval, remaining))
 
         action_attempt = get_action_attempt(client, action_attempt_id)
 
-    if action_attempt.status == "error":
-        raise SeamActionAttemptFailedError(action_attempt)
+    if _status_of(action_attempt) == "error":
+        raise SeamActionAttemptFailedError(cast(ErrorActionAttempt, action_attempt))
 
-    return action_attempt
+    # Neither pending, success, nor error: a status added after this SDK release.
+    # Waiting cannot conclude, so say so rather than pass it off as a success.
+    status = _status_of(action_attempt)
+    if status != "success":
+        raise SeamActionAttemptUnknownStatusError(action_attempt, str(status))
+
+    return cast(SuccessActionAttempt, action_attempt)
 
 
 def resolve_action_attempt(
@@ -165,20 +193,28 @@ async def poll_until_ready_async(
     if action_attempt is None:
         action_attempt = await get_action_attempt_async(client, action_attempt_id)
 
-    while action_attempt.status == "pending":
+    while _status_of(action_attempt) == "pending":
         remaining = deadline - time.monotonic()
 
         if remaining <= 0:
-            raise SeamActionAttemptTimeoutError(action_attempt, timeout)
+            raise SeamActionAttemptTimeoutError(
+                cast(PendingActionAttempt, action_attempt), timeout
+            )
 
         await asyncio.sleep(min(polling_interval, remaining))
 
         action_attempt = await get_action_attempt_async(client, action_attempt_id)
 
-    if action_attempt.status == "error":
-        raise SeamActionAttemptFailedError(action_attempt)
+    if _status_of(action_attempt) == "error":
+        raise SeamActionAttemptFailedError(cast(ErrorActionAttempt, action_attempt))
 
-    return action_attempt
+    # Neither pending, success, nor error: a status added after this SDK release.
+    # Waiting cannot conclude, so say so rather than pass it off as a success.
+    status = _status_of(action_attempt)
+    if status != "success":
+        raise SeamActionAttemptUnknownStatusError(action_attempt, str(status))
+
+    return cast(SuccessActionAttempt, action_attempt)
 
 
 async def resolve_action_attempt_async(

--- a/seam/modules/action_attempts.py
+++ b/seam/modules/action_attempts.py
@@ -25,11 +25,7 @@ WAIT_FOR_ACTION_ATTEMPT_OPTION_KEYS = ("timeout", "polling_interval")
 
 
 def _status_of(action_attempt: ActionAttempt) -> Optional[str]:
-    """Read the status without assuming the attempt carries one.
-
-    An attempt from a newer API deserializes to a DeepAttrDict, where a missing
-    key raises rather than reading as None.
-    """
+    """Read the status, which a DeepAttrDict fallback may not carry."""
 
     return getattr(action_attempt, "status", None)
 
@@ -128,8 +124,6 @@ def poll_until_ready(
     if _status_of(action_attempt) == "error":
         raise SeamActionAttemptFailedError(cast(ErrorActionAttempt, action_attempt))
 
-    # Neither pending, success, nor error: a status added after this SDK release.
-    # Waiting cannot conclude, so say so rather than pass it off as a success.
     status = _status_of(action_attempt)
     if status != "success":
         raise SeamActionAttemptUnknownStatusError(action_attempt, str(status))
@@ -208,8 +202,6 @@ async def poll_until_ready_async(
     if _status_of(action_attempt) == "error":
         raise SeamActionAttemptFailedError(cast(ErrorActionAttempt, action_attempt))
 
-    # Neither pending, success, nor error: a status added after this SDK release.
-    # Waiting cannot conclude, so say so rather than pass it off as a success.
     status = _status_of(action_attempt)
     if status != "success":
         raise SeamActionAttemptUnknownStatusError(action_attempt, str(status))

--- a/seam/parse.py
+++ b/seam/parse.py
@@ -1,0 +1,99 @@
+"""Total conversion helpers shared by the generated resource dataclasses.
+
+The Seam API grows new event types, action types, and error codes between SDK
+releases, so reading a response must never fail on the shape of the payload.
+Every helper here degrades instead of raising: an unusable value becomes
+``None``, an empty list, or a :class:`DeepAttrDict` carrying the payload
+verbatim, so one unexpected field cannot cost the caller the whole response.
+
+The narrow cost is that a genuinely malformed payload is no longer loud. The
+payload survives on the returned object, so it stays diagnosable.
+"""
+
+from typing import Any, Dict, List
+
+from .deep_attr_dict import DeepAttrDict
+
+
+def record_from_dict(value: Any) -> Any:
+    """Wrap a free-form record for attribute access, passing anything else through.
+
+    A record the API sends as something other than an object degrades to the raw
+    value rather than costing the caller the whole surrounding resource.
+    """
+
+    return DeepAttrDict(value) if isinstance(value, dict) else value
+
+
+def object_from_dict(cls: Any, value: Any) -> Any:
+    """Convert an optional nested object, or None when it is unusable."""
+
+    if not isinstance(value, dict):
+        return None
+
+    try:
+        return cls.from_dict(value)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return DeepAttrDict(value)
+
+
+def required_object_from_dict(cls: Any, value: Any) -> Any:
+    """Convert a nested object the caller may always read, never returning None."""
+
+    source = value if isinstance(value, dict) else {}
+
+    try:
+        return cls.from_dict(source)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return DeepAttrDict(source)
+
+
+def object_list_from_dict(cls: Any, value: Any) -> List[Any]:
+    """Convert a list of nested objects, skipping nothing and raising for nothing.
+
+    A value that is not a list reads as empty, so callers can always iterate.
+    """
+
+    if not isinstance(value, list):
+        return []
+
+    return [
+        object_from_dict(cls, item) if isinstance(item, dict) else item
+        for item in value
+    ]
+
+
+def discriminated_from_dict(
+    value: Any, variants: Dict[str, Any], discriminator: str
+) -> Any:
+    """Convert one member of a discriminated union.
+
+    An unrecognized discriminator, or a known one whose payload does not
+    convert, yields a DeepAttrDict so a newer API stays readable.
+    """
+
+    if not isinstance(value, dict):
+        # Not an object at all; hand it back untouched rather than lose it.
+        return value
+
+    key = value.get(discriminator)
+    variant = variants.get(key) if isinstance(key, str) else None
+
+    if variant is None:
+        return DeepAttrDict(value)
+
+    try:
+        return variant.from_dict(value)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return DeepAttrDict(value)
+
+
+def discriminated_list_from_dict(
+    value: Any, variants: Dict[str, Any], discriminator: str
+) -> List[Any]:
+    """Convert a list of discriminated union members, degrading item by item."""
+
+    if not isinstance(value, list):
+        return []
+
+    return [discriminated_from_dict(item, variants, discriminator) for item in value]

--- a/seam/parse.py
+++ b/seam/parse.py
@@ -1,13 +1,8 @@
-"""Total conversion helpers shared by the generated resource dataclasses.
+"""Convert response payloads without raising on their shape.
 
-The Seam API grows new event types, action types, and error codes between SDK
-releases, so reading a response must never fail on the shape of the payload.
-Every helper here degrades instead of raising: an unusable value becomes
-``None``, an empty list, or a :class:`DeepAttrDict` carrying the payload
-verbatim, so one unexpected field cannot cost the caller the whole response.
-
-The narrow cost is that a genuinely malformed payload is no longer loud. The
-payload survives on the returned object, so it stays diagnosable.
+Seam adds event types, action types, and error codes between SDK releases, so a
+value in an unexpected shape degrades to None, an empty list, or a DeepAttrDict
+rather than costing the caller the whole response.
 """
 
 from typing import Any, Dict, List
@@ -16,11 +11,7 @@ from .deep_attr_dict import DeepAttrDict
 
 
 def record_from_dict(value: Any) -> Any:
-    """Wrap a free-form record for attribute access, passing anything else through.
-
-    A record the API sends as something other than an object degrades to the raw
-    value rather than costing the caller the whole surrounding resource.
-    """
+    """Wrap a free-form record for attribute access, passing anything else through."""
 
     return DeepAttrDict(value) if isinstance(value, dict) else value
 
@@ -49,10 +40,7 @@ def required_object_from_dict(cls: Any, value: Any) -> Any:
 
 
 def object_list_from_dict(cls: Any, value: Any) -> List[Any]:
-    """Convert a list of nested objects, skipping nothing and raising for nothing.
-
-    A value that is not a list reads as empty, so callers can always iterate.
-    """
+    """Convert a list of nested objects, reading a non-list as empty."""
 
     if not isinstance(value, list):
         return []
@@ -69,11 +57,10 @@ def discriminated_from_dict(
     """Convert one member of a discriminated union.
 
     An unrecognized discriminator, or a known one whose payload does not
-    convert, yields a DeepAttrDict so a newer API stays readable.
+    convert, yields a DeepAttrDict.
     """
 
     if not isinstance(value, dict):
-        # Not an object at all; hand it back untouched rather than lose it.
         return value
 
     key = value.get(discriminator)
@@ -91,7 +78,7 @@ def discriminated_from_dict(
 def discriminated_list_from_dict(
     value: Any, variants: Dict[str, Any], discriminator: str
 ) -> List[Any]:
-    """Convert a list of discriminated union members, degrading item by item."""
+    """Convert a list of discriminated union members, reading a non-list as empty."""
 
     if not isinstance(value, list):
         return []

--- a/seam/resources/access_code.py
+++ b/seam/resources/access_code.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -104,6 +104,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 is_cancellable=d.get("is_cancellable", None),
                 is_early_checkin_able=d.get("is_early_checkin_able", None),
@@ -135,6 +137,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -162,6 +166,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -189,6 +195,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -222,6 +230,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -251,6 +261,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -291,6 +303,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     field=d.get("field", None),
                     from_=d.get("from", None),
@@ -306,16 +320,17 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 change_type=d.get("change_type", None),
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
                 is_access_code_error=d.get("is_access_code_error", None),
                 message=d.get("message", None),
-                modified_fields=[
-                    cls.ModifiedFields.from_dict(i)
-                    for i in d.get("modified_fields") or []
-                ],
+                modified_fields=_object_list_from_dict(
+                    cls.ModifiedFields, d.get("modified_fields")
+                ),
             )
 
     @dataclass
@@ -338,6 +353,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -365,6 +382,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -392,6 +411,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -419,6 +440,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -446,6 +469,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -476,6 +501,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -507,6 +534,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -538,6 +567,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -569,6 +600,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -597,6 +630,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -624,6 +659,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -651,6 +688,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -678,6 +717,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -705,6 +746,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -732,6 +775,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -759,6 +804,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -786,6 +833,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -813,6 +862,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -843,6 +894,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -868,6 +921,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -894,6 +949,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -918,6 +975,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -948,6 +1007,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     code=d.get("code", None),
                 )
@@ -962,6 +1023,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     code=d.get("code", None),
                 )
@@ -974,16 +1037,14 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -1010,6 +1071,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     name=d.get("name", None),
                 )
@@ -1024,6 +1087,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     name=d.get("name", None),
                 )
@@ -1036,16 +1101,14 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -1075,6 +1138,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -1093,6 +1158,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -1106,16 +1173,14 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -1135,6 +1200,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1158,6 +1225,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1195,6 +1264,8 @@ class AccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     field=d.get("field", None),
                     from_=d.get("from", None),
@@ -1209,14 +1280,15 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 change_type=d.get("change_type", None),
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
-                modified_fields=[
-                    cls.ModifiedFields.from_dict(i)
-                    for i in d.get("modified_fields") or []
-                ],
+                modified_fields=_object_list_from_dict(
+                    cls.ModifiedFields, d.get("modified_fields")
+                ),
                 warning_code=d.get("warning_code", None),
             )
 
@@ -1237,6 +1309,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1260,6 +1334,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1283,6 +1359,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1306,6 +1384,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1329,6 +1409,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1352,6 +1434,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1375,6 +1459,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1398,6 +1484,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1421,6 +1509,8 @@ class AccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1555,24 +1645,21 @@ class AccessCode:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             code=d.get("code", None),
             common_code_key=d.get("common_code_key", None),
             created_at=d.get("created_at", None),
             device_id=d.get("device_id", None),
-            dormakaba_oracode_metadata=(
-                cls.DormakabaOracodeMetadata.from_dict(
-                    d.get("dormakaba_oracode_metadata")
-                )
-                if d.get("dormakaba_oracode_metadata") is not None
-                else None
+            dormakaba_oracode_metadata=_object_from_dict(
+                cls.DormakabaOracodeMetadata, d.get("dormakaba_oracode_metadata")
             ),
             ends_at=d.get("ends_at", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             is_backup=d.get("is_backup", None),
             is_backup_access_code_available=d.get(
                 "is_backup_access_code_available", None
@@ -1588,19 +1675,17 @@ class AccessCode:
                 "is_waiting_for_code_assignment", None
             ),
             name=d.get("name", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
             pulled_backup_access_code_id=d.get("pulled_backup_access_code_id", None),
             starts_at=d.get("starts_at", None),
             status=d.get("status", None),
             type=d.get("type", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/access_grant.py
+++ b/seam/resources/access_grant.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -77,6 +77,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -108,6 +110,8 @@ class AccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -125,6 +129,8 @@ class AccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     common_code_key=d.get("common_code_key", None),
                     device_ids=d.get("device_ids", None),
@@ -138,16 +144,14 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -179,6 +183,8 @@ class AccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -197,6 +203,8 @@ class AccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -211,17 +219,15 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method_ids=d.get("access_method_ids", None),
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -250,6 +256,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 code=d.get("code", None),
                 created_access_method_ids=d.get("created_access_method_ids", None),
@@ -276,6 +284,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -299,6 +309,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -334,6 +346,8 @@ class AccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     error_code=d.get("error_code", None),
@@ -347,12 +361,13 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                failed_devices=[
-                    cls.FailedDevices.from_dict(i)
-                    for i in d.get("failed_devices") or []
-                ],
+                failed_devices=_object_list_from_dict(
+                    cls.FailedDevices, d.get("failed_devices")
+                ),
                 message=d.get("message", None),
                 warning_code=d.get("warning_code", None),
             )
@@ -377,6 +392,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method_ids=d.get("access_method_ids", None),
                 created_at=d.get("created_at", None),
@@ -410,6 +427,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -439,6 +458,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -471,6 +492,8 @@ class AccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -535,6 +558,8 @@ class AccessGrant:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             access_grant_key=d.get("access_grant_key", None),
@@ -545,30 +570,26 @@ class AccessGrant:
             display_name=d.get("display_name", None),
             display_status=d.get("display_status", None),
             ends_at=d.get("ends_at", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             instant_key_url=d.get("instant_key_url", None),
             location_ids=d.get("location_ids", None),
             name=d.get("name", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            requested_access_methods=[
-                cls.RequestedAccessMethods.from_dict(i)
-                for i in d.get("requested_access_methods") or []
-            ],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
+            requested_access_methods=_object_list_from_dict(
+                cls.RequestedAccessMethods, d.get("requested_access_methods")
+            ),
             reservation_key=d.get("reservation_key", None),
             space_ids=d.get("space_ids", None),
             starts_at=d.get("starts_at", None),
             user_identity_id=d.get("user_identity_id", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/access_method.py
+++ b/seam/resources/access_method.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -70,6 +70,8 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -100,6 +102,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -114,6 +118,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -126,16 +132,14 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -162,6 +166,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -176,6 +182,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -188,16 +196,14 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -227,6 +233,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -245,6 +253,8 @@ class AccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -258,16 +268,14 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -287,6 +295,8 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -310,6 +320,8 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -336,6 +348,8 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -360,6 +374,8 @@ class AccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -417,6 +433,8 @@ class AccessMethod:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_method_id=d.get("access_method_id", None),
             client_session_token=d.get("client_session_token", None),
@@ -425,10 +443,9 @@ class AccessMethod:
             customization_profile_id=d.get("customization_profile_id", None),
             display_name=d.get("display_name", None),
             display_status=d.get("display_status", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             instant_key_url=d.get("instant_key_url", None),
             is_assignment_required=d.get("is_assignment_required", None),
             is_encoding_required=d.get("is_encoding_required", None),
@@ -437,15 +454,13 @@ class AccessMethod:
             is_ready_for_encoding=d.get("is_ready_for_encoding", None),
             issued_at=d.get("issued_at", None),
             mode=d.get("mode", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/acs_access_group.py
+++ b/seam/resources/acs_access_group.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -65,6 +65,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 ends_at=d.get("ends_at", None),
                 starts_at=d.get("starts_at", None),
@@ -87,6 +89,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -110,6 +114,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -133,6 +139,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -156,6 +164,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -186,6 +196,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     name=d.get("name", None),
                 )
@@ -200,6 +212,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     name=d.get("name", None),
                 )
@@ -212,16 +226,14 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -251,6 +263,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -269,6 +283,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -282,16 +298,14 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -318,6 +332,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_user_id=d.get("acs_user_id", None),
                 )
@@ -332,6 +348,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_user_id=d.get("acs_user_id", None),
                 )
@@ -344,16 +362,14 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -380,6 +396,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_entrance_id=d.get("acs_entrance_id", None),
                 )
@@ -394,6 +412,8 @@ class AcsAccessGroup:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_entrance_id=d.get("acs_entrance_id", None),
                 )
@@ -406,16 +426,14 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -441,6 +459,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 acs_user_id=d.get("acs_user_id", None),
                 created_at=d.get("created_at", None),
@@ -466,6 +486,8 @@ class AcsAccessGroup:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -539,35 +561,33 @@ class AcsAccessGroup:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_group_type=d.get("access_group_type", None),
             access_group_type_display_name=d.get(
                 "access_group_type_display_name", None
             ),
-            access_schedule=(
-                cls.AccessSchedule.from_dict(d.get("access_schedule"))
-                if d.get("access_schedule") is not None
-                else None
+            access_schedule=_object_from_dict(
+                cls.AccessSchedule, d.get("access_schedule")
             ),
             acs_access_group_id=d.get("acs_access_group_id", None),
             acs_system_id=d.get("acs_system_id", None),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             external_type=d.get("external_type", None),
             external_type_display_name=d.get("external_type_display_name", None),
             is_managed=d.get("is_managed", None),
             name=d.get("name", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
+            warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/acs_credential.py
+++ b/seam/resources/acs_credential.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -90,6 +90,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 member_pin_id=d.get("member_pin_id", None),
             )
@@ -120,6 +122,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 auto_join=d.get("auto_join", None),
                 door_names=d.get("door_names", None),
@@ -147,6 +151,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -185,6 +191,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 auto_join=d.get("auto_join", None),
                 card_function_type=d.get("card_function_type", None),
@@ -213,6 +221,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -236,6 +246,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -259,6 +271,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -282,6 +296,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -305,6 +321,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -328,6 +346,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -357,6 +377,8 @@ class AcsCredential:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -433,23 +455,19 @@ class AcsCredential:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_method=d.get("access_method", None),
             acs_credential_id=d.get("acs_credential_id", None),
             acs_credential_pool_id=d.get("acs_credential_pool_id", None),
             acs_system_id=d.get("acs_system_id", None),
             acs_user_id=d.get("acs_user_id", None),
-            akiles_metadata=(
-                cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                if d.get("akiles_metadata") is not None
-                else None
+            akiles_metadata=_object_from_dict(
+                cls.AkilesMetadata, d.get("akiles_metadata")
             ),
-            assa_abloy_vostio_metadata=(
-                cls.AssaAbloyVostioMetadata.from_dict(
-                    d.get("assa_abloy_vostio_metadata")
-                )
-                if d.get("assa_abloy_vostio_metadata") is not None
-                else None
+            assa_abloy_vostio_metadata=_object_from_dict(
+                cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
             ),
             card_number=d.get("card_number", None),
             code=d.get("code", None),
@@ -457,7 +475,7 @@ class AcsCredential:
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
             ends_at=d.get("ends_at", None),
-            errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+            errors=_object_list_from_dict(cls.Errors, d.get("errors")),
             external_type=d.get("external_type", None),
             external_type_display_name=d.get("external_type_display_name", None),
             is_issued=d.get("is_issued", None),
@@ -476,14 +494,11 @@ class AcsCredential:
             parent_acs_credential_id=d.get("parent_acs_credential_id", None),
             starts_at=d.get("starts_at", None),
             user_identity_id=d.get("user_identity_id", None),
-            visionline_metadata=(
-                cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                if d.get("visionline_metadata") is not None
-                else None
+            visionline_metadata=_object_from_dict(
+                cls.VisionlineMetadata, d.get("visionline_metadata")
             ),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/acs_encoder.py
+++ b/seam/resources/acs_encoder.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -53,6 +60,8 @@ class AcsEncoder:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -69,12 +78,14 @@ class AcsEncoder:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_encoder_id=d.get("acs_encoder_id", None),
             acs_system_id=d.get("acs_system_id", None),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
-            errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+            errors=_object_list_from_dict(cls.Errors, d.get("errors")),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/acs_entrance.py
+++ b/seam/resources/acs_entrance.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -93,6 +93,8 @@ class AcsEntrance:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     id=d.get("id", None),
                     name=d.get("name", None),
@@ -105,8 +107,10 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                actions=[cls.Actions.from_dict(i) for i in d.get("actions") or []],
+                actions=_object_list_from_dict(cls.Actions, d.get("actions")),
                 gadget_id=d.get("gadget_id", None),
                 site_id=d.get("site_id", None),
                 site_name=d.get("site_name", None),
@@ -137,6 +141,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 door_name=d.get("door_name", None),
                 door_number=d.get("door_number", None),
@@ -173,6 +179,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 entry_name=d.get("entry_name", None),
                 entry_relays_total_count=d.get("entry_relays_total_count", None),
@@ -199,6 +207,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_point_id=d.get("access_point_id", None),
                 site_id=d.get("site_id", None),
@@ -216,6 +226,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_point_name=d.get("access_point_name", None),
             )
@@ -231,6 +243,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_point_profile=d.get("access_point_profile", None),
             )
@@ -252,6 +266,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -274,6 +290,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 common_area_name=d.get("common_area_name", None),
                 common_area_number=d.get("common_area_number", None),
@@ -299,6 +317,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 accessibility_type=d.get("accessibility_type", None),
                 door_name=d.get("door_name", None),
@@ -337,6 +357,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 battery_level=d.get("battery_level", None),
                 door_name=d.get("door_name", None),
@@ -373,6 +395,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 audit_on_keys=d.get("audit_on_keys", None),
                 door_description=d.get("door_description", None),
@@ -408,6 +432,8 @@ class AcsEntrance:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     visionline_door_profile_id=d.get(
                         "visionline_door_profile_id", None
@@ -425,10 +451,12 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 door_category=d.get("door_category", None),
                 door_name=d.get("door_name", None),
-                profiles=[cls.Profiles.from_dict(i) for i in d.get("profiles") or []],
+                profiles=_object_list_from_dict(cls.Profiles, d.get("profiles")),
             )
 
     @dataclass
@@ -448,6 +476,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -471,6 +501,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -494,6 +526,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -517,6 +551,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -540,6 +576,8 @@ class AcsEntrance:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -589,30 +627,22 @@ class AcsEntrance:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_id=d.get("acs_entrance_id", None),
             acs_system_id=d.get("acs_system_id", None),
-            akiles_metadata=(
-                cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                if d.get("akiles_metadata") is not None
-                else None
+            akiles_metadata=_object_from_dict(
+                cls.AkilesMetadata, d.get("akiles_metadata")
             ),
-            assa_abloy_vostio_metadata=(
-                cls.AssaAbloyVostioMetadata.from_dict(
-                    d.get("assa_abloy_vostio_metadata")
-                )
-                if d.get("assa_abloy_vostio_metadata") is not None
-                else None
+            assa_abloy_vostio_metadata=_object_from_dict(
+                cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
             ),
-            avigilon_alta_metadata=(
-                cls.AvigilonAltaMetadata.from_dict(d.get("avigilon_alta_metadata"))
-                if d.get("avigilon_alta_metadata") is not None
-                else None
+            avigilon_alta_metadata=_object_from_dict(
+                cls.AvigilonAltaMetadata, d.get("avigilon_alta_metadata")
             ),
-            brivo_metadata=(
-                cls.BrivoMetadata.from_dict(d.get("brivo_metadata"))
-                if d.get("brivo_metadata") is not None
-                else None
+            brivo_metadata=_object_from_dict(
+                cls.BrivoMetadata, d.get("brivo_metadata")
             ),
             can_belong_to_reservation=d.get("can_belong_to_reservation", None),
             can_unlock_with_card=d.get("can_unlock_with_card", None),
@@ -622,50 +652,31 @@ class AcsEntrance:
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
-            dormakaba_ambiance_metadata=(
-                cls.DormakabaAmbianceMetadata.from_dict(
-                    d.get("dormakaba_ambiance_metadata")
-                )
-                if d.get("dormakaba_ambiance_metadata") is not None
-                else None
+            dormakaba_ambiance_metadata=_object_from_dict(
+                cls.DormakabaAmbianceMetadata, d.get("dormakaba_ambiance_metadata")
             ),
-            dormakaba_community_metadata=(
-                cls.DormakabaCommunityMetadata.from_dict(
-                    d.get("dormakaba_community_metadata")
-                )
-                if d.get("dormakaba_community_metadata") is not None
-                else None
+            dormakaba_community_metadata=_object_from_dict(
+                cls.DormakabaCommunityMetadata, d.get("dormakaba_community_metadata")
             ),
-            errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
-            hotek_metadata=(
-                cls.HotekMetadata.from_dict(d.get("hotek_metadata"))
-                if d.get("hotek_metadata") is not None
-                else None
+            errors=_object_list_from_dict(cls.Errors, d.get("errors")),
+            hotek_metadata=_object_from_dict(
+                cls.HotekMetadata, d.get("hotek_metadata")
             ),
             is_locked=d.get("is_locked", None),
-            latch_metadata=(
-                cls.LatchMetadata.from_dict(d.get("latch_metadata"))
-                if d.get("latch_metadata") is not None
-                else None
+            latch_metadata=_object_from_dict(
+                cls.LatchMetadata, d.get("latch_metadata")
             ),
-            salto_ks_metadata=(
-                cls.SaltoKsMetadata.from_dict(d.get("salto_ks_metadata"))
-                if d.get("salto_ks_metadata") is not None
-                else None
+            salto_ks_metadata=_object_from_dict(
+                cls.SaltoKsMetadata, d.get("salto_ks_metadata")
             ),
-            salto_space_metadata=(
-                cls.SaltoSpaceMetadata.from_dict(d.get("salto_space_metadata"))
-                if d.get("salto_space_metadata") is not None
-                else None
+            salto_space_metadata=_object_from_dict(
+                cls.SaltoSpaceMetadata, d.get("salto_space_metadata")
             ),
             space_ids=d.get("space_ids", None),
-            visionline_metadata=(
-                cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                if d.get("visionline_metadata") is not None
-                else None
+            visionline_metadata=_object_from_dict(
+                cls.VisionlineMetadata, d.get("visionline_metadata")
             ),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
         )

--- a/seam/resources/acs_system.py
+++ b/seam/resources/acs_system.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -79,6 +79,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -106,6 +108,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -132,6 +136,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -155,6 +161,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -178,6 +186,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -201,6 +211,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -224,6 +236,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -247,6 +261,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -270,6 +286,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -287,6 +305,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 time_zone=d.get("time_zone", None),
             )
@@ -308,6 +328,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 lan_address=d.get("lan_address", None),
                 mobile_access_uuid=d.get("mobile_access_uuid", None),
@@ -331,6 +353,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -357,6 +381,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -383,6 +409,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -406,6 +434,8 @@ class AcsSystem:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -511,6 +541,8 @@ class AcsSystem:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_access_group_count=d.get("acs_access_group_count", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -521,31 +553,23 @@ class AcsSystem:
             default_credential_manager_acs_system_id=d.get(
                 "default_credential_manager_acs_system_id", None
             ),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             external_type=d.get("external_type", None),
             external_type_display_name=d.get("external_type_display_name", None),
             image_alt_text=d.get("image_alt_text", None),
             image_url=d.get("image_url", None),
             is_credential_manager=d.get("is_credential_manager", None),
-            location=(
-                cls.Location.from_dict(d.get("location"))
-                if d.get("location") is not None
-                else None
-            ),
+            location=_object_from_dict(cls.Location, d.get("location")),
             name=d.get("name", None),
             system_type=d.get("system_type", None),
             system_type_display_name=d.get("system_type_display_name", None),
-            visionline_metadata=(
-                cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                if d.get("visionline_metadata") is not None
-                else None
+            visionline_metadata=_object_from_dict(
+                cls.VisionlineMetadata, d.get("visionline_metadata")
             ),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/acs_user.py
+++ b/seam/resources/acs_user.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -84,6 +84,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 ends_at=d.get("ends_at", None),
                 starts_at=d.get("starts_at", None),
@@ -106,6 +108,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -129,6 +133,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -152,6 +158,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -175,6 +183,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -198,6 +208,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -221,6 +233,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -244,6 +258,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -267,6 +283,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -292,6 +310,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -329,6 +349,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     email_address=d.get("email_address", None),
                     full_name=d.get("full_name", None),
@@ -351,6 +373,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     email_address=d.get("email_address", None),
                     full_name=d.get("full_name", None),
@@ -365,16 +389,14 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -404,6 +426,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -422,6 +446,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -435,16 +461,14 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -471,6 +495,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     is_suspended=d.get("is_suspended", None),
                 )
@@ -485,6 +511,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     is_suspended=d.get("is_suspended", None),
                 )
@@ -497,16 +525,14 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -533,6 +559,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_access_group_id=d.get("acs_access_group_id", None),
                 )
@@ -547,6 +575,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_access_group_id=d.get("acs_access_group_id", None),
                 )
@@ -559,16 +589,14 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -594,6 +622,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 acs_access_group_id=d.get("acs_access_group_id", None),
                 created_at=d.get("created_at", None),
@@ -626,6 +656,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_credential_id=d.get("acs_credential_id", None),
                 )
@@ -640,6 +672,8 @@ class AcsUser:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     acs_credential_id=d.get("acs_credential_id", None),
                 )
@@ -652,16 +686,14 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -675,6 +707,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 is_subscribed=d.get("is_subscribed", None),
             )
@@ -692,6 +726,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 audit_openings=d.get("audit_openings", None),
                 user_id=d.get("user_id", None),
@@ -713,6 +749,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -735,6 +773,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -757,6 +797,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -779,6 +821,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -801,6 +845,8 @@ class AcsUser:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -902,11 +948,11 @@ class AcsUser:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_schedule=(
-                cls.AccessSchedule.from_dict(d.get("access_schedule"))
-                if d.get("access_schedule") is not None
-                else None
+            access_schedule=_object_from_dict(
+                cls.AccessSchedule, d.get("access_schedule")
             ),
             acs_system_id=d.get("acs_system_id", None),
             acs_user_id=d.get("acs_user_id", None),
@@ -915,40 +961,33 @@ class AcsUser:
             display_name=d.get("display_name", None),
             email=d.get("email", None),
             email_address=d.get("email_address", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             external_type=d.get("external_type", None),
             external_type_display_name=d.get("external_type_display_name", None),
             full_name=d.get("full_name", None),
             hid_acs_system_id=d.get("hid_acs_system_id", None),
             is_managed=d.get("is_managed", None),
             is_suspended=d.get("is_suspended", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            phone_number=d.get("phone_number", None),
-            salto_ks_metadata=(
-                cls.SaltoKsMetadata.from_dict(d.get("salto_ks_metadata"))
-                if d.get("salto_ks_metadata") is not None
-                else None
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
             ),
-            salto_space_metadata=(
-                cls.SaltoSpaceMetadata.from_dict(d.get("salto_space_metadata"))
-                if d.get("salto_space_metadata") is not None
-                else None
+            phone_number=d.get("phone_number", None),
+            salto_ks_metadata=_object_from_dict(
+                cls.SaltoKsMetadata, d.get("salto_ks_metadata")
+            ),
+            salto_space_metadata=_object_from_dict(
+                cls.SaltoSpaceMetadata, d.get("salto_space_metadata")
             ),
             user_identity_email_address=d.get("user_identity_email_address", None),
             user_identity_full_name=d.get("user_identity_full_name", None),
             user_identity_id=d.get("user_identity_id", None),
             user_identity_phone_number=d.get("user_identity_phone_number", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/action_attempt.py
+++ b/seam/resources/action_attempt.py
@@ -4476,5 +4476,4 @@ def action_attempt_from_dict(d: Any) -> ActionAttempt:
     try:
         return variant.from_dict(d)
     except Exception:  # pylint: disable=broad-exception-caught
-        # A known discriminator whose payload does not convert is still readable.
         return cast(ActionAttempt, DeepAttrDict(d))

--- a/seam/resources/action_attempt.py
+++ b/seam/resources/action_attempt.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -29,6 +36,8 @@ class LockDoorSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 was_confirmed_by_device=d.get("was_confirmed_by_device", None),
             )
@@ -41,11 +50,13 @@ class LockDoorSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -72,6 +83,8 @@ class LockDoorPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -108,6 +121,8 @@ class LockDoorErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -121,10 +136,12 @@ class LockDoorErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -155,6 +172,8 @@ class UnlockDoorSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 was_confirmed_by_device=d.get("was_confirmed_by_device", None),
             )
@@ -167,11 +186,13 @@ class UnlockDoorSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -198,6 +219,8 @@ class UnlockDoorPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -234,6 +257,8 @@ class UnlockDoorErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -247,10 +272,12 @@ class UnlockDoorErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -342,6 +369,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         cancelled=d.get("cancelled", None),
                         card_format=d.get("card_format", None),
@@ -366,16 +395,16 @@ class ScanCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     card_number=d.get("card_number", None),
                     created_at=d.get("created_at", None),
                     ends_at=d.get("ends_at", None),
                     is_issued=d.get("is_issued", None),
                     starts_at=d.get("starts_at", None),
-                    visionline_metadata=(
-                        cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                        if d.get("visionline_metadata") is not None
-                        else None
+                    visionline_metadata=_object_from_dict(
+                        cls.VisionlineMetadata, d.get("visionline_metadata")
                     ),
                 )
 
@@ -452,6 +481,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         member_pin_id=d.get("member_pin_id", None),
                     )
@@ -482,6 +513,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         auto_join=d.get("auto_join", None),
                         door_names=d.get("door_names", None),
@@ -509,6 +542,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         created_at=d.get("created_at", None),
                         error_code=d.get("error_code", None),
@@ -547,6 +582,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         auto_join=d.get("auto_join", None),
                         card_function_type=d.get("card_function_type", None),
@@ -591,6 +628,8 @@ class ScanCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         created_at=d.get("created_at", None),
                         message=d.get("message", None),
@@ -648,23 +687,19 @@ class ScanCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     access_method=d.get("access_method", None),
                     acs_credential_id=d.get("acs_credential_id", None),
                     acs_credential_pool_id=d.get("acs_credential_pool_id", None),
                     acs_system_id=d.get("acs_system_id", None),
                     acs_user_id=d.get("acs_user_id", None),
-                    akiles_metadata=(
-                        cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                        if d.get("akiles_metadata") is not None
-                        else None
+                    akiles_metadata=_object_from_dict(
+                        cls.AkilesMetadata, d.get("akiles_metadata")
                     ),
-                    assa_abloy_vostio_metadata=(
-                        cls.AssaAbloyVostioMetadata.from_dict(
-                            d.get("assa_abloy_vostio_metadata")
-                        )
-                        if d.get("assa_abloy_vostio_metadata") is not None
-                        else None
+                    assa_abloy_vostio_metadata=_object_from_dict(
+                        cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
                     ),
                     card_number=d.get("card_number", None),
                     code=d.get("code", None),
@@ -672,7 +707,7 @@ class ScanCredentialSuccessActionAttempt:
                     created_at=d.get("created_at", None),
                     display_name=d.get("display_name", None),
                     ends_at=d.get("ends_at", None),
-                    errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+                    errors=_object_list_from_dict(cls.Errors, d.get("errors")),
                     external_type=d.get("external_type", None),
                     external_type_display_name=d.get(
                         "external_type_display_name", None
@@ -693,14 +728,10 @@ class ScanCredentialSuccessActionAttempt:
                     parent_acs_credential_id=d.get("parent_acs_credential_id", None),
                     starts_at=d.get("starts_at", None),
                     user_identity_id=d.get("user_identity_id", None),
-                    visionline_metadata=(
-                        cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                        if d.get("visionline_metadata") is not None
-                        else None
+                    visionline_metadata=_object_from_dict(
+                        cls.VisionlineMetadata, d.get("visionline_metadata")
                     ),
-                    warnings=[
-                        cls.Warnings.from_dict(i) for i in d.get("warnings") or []
-                    ],
+                    warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
                     workspace_id=d.get("workspace_id", None),
                 )
 
@@ -721,6 +752,8 @@ class ScanCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     warning_code=d.get("warning_code", None),
                     warning_message=d.get("warning_message", None),
@@ -732,20 +765,16 @@ class ScanCredentialSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                acs_credential_on_encoder=(
-                    cls.AcsCredentialOnEncoder.from_dict(
-                        d.get("acs_credential_on_encoder")
-                    )
-                    if d.get("acs_credential_on_encoder") is not None
-                    else None
+                acs_credential_on_encoder=_object_from_dict(
+                    cls.AcsCredentialOnEncoder, d.get("acs_credential_on_encoder")
                 ),
-                acs_credential_on_seam=(
-                    cls.AcsCredentialOnSeam.from_dict(d.get("acs_credential_on_seam"))
-                    if d.get("acs_credential_on_seam") is not None
-                    else None
+                acs_credential_on_seam=_object_from_dict(
+                    cls.AcsCredentialOnSeam, d.get("acs_credential_on_seam")
                 ),
-                warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+                warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
             )
 
     action_attempt_id: str
@@ -756,11 +785,13 @@ class ScanCredentialSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -787,6 +818,8 @@ class ScanCredentialPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -831,6 +864,8 @@ class ScanCredentialErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -844,10 +879,12 @@ class ScanCredentialErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -940,6 +977,8 @@ class EncodeCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     member_pin_id=d.get("member_pin_id", None),
                 )
@@ -970,6 +1009,8 @@ class EncodeCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     auto_join=d.get("auto_join", None),
                     door_names=d.get("door_names", None),
@@ -997,6 +1038,8 @@ class EncodeCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     error_code=d.get("error_code", None),
@@ -1035,6 +1078,8 @@ class EncodeCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     auto_join=d.get("auto_join", None),
                     card_function_type=d.get("card_function_type", None),
@@ -1077,6 +1122,8 @@ class EncodeCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     message=d.get("message", None),
@@ -1134,23 +1181,19 @@ class EncodeCredentialSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method=d.get("access_method", None),
                 acs_credential_id=d.get("acs_credential_id", None),
                 acs_credential_pool_id=d.get("acs_credential_pool_id", None),
                 acs_system_id=d.get("acs_system_id", None),
                 acs_user_id=d.get("acs_user_id", None),
-                akiles_metadata=(
-                    cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                    if d.get("akiles_metadata") is not None
-                    else None
+                akiles_metadata=_object_from_dict(
+                    cls.AkilesMetadata, d.get("akiles_metadata")
                 ),
-                assa_abloy_vostio_metadata=(
-                    cls.AssaAbloyVostioMetadata.from_dict(
-                        d.get("assa_abloy_vostio_metadata")
-                    )
-                    if d.get("assa_abloy_vostio_metadata") is not None
-                    else None
+                assa_abloy_vostio_metadata=_object_from_dict(
+                    cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
                 ),
                 card_number=d.get("card_number", None),
                 code=d.get("code", None),
@@ -1158,7 +1201,7 @@ class EncodeCredentialSuccessActionAttempt:
                 created_at=d.get("created_at", None),
                 display_name=d.get("display_name", None),
                 ends_at=d.get("ends_at", None),
-                errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+                errors=_object_list_from_dict(cls.Errors, d.get("errors")),
                 external_type=d.get("external_type", None),
                 external_type_display_name=d.get("external_type_display_name", None),
                 is_issued=d.get("is_issued", None),
@@ -1177,12 +1220,10 @@ class EncodeCredentialSuccessActionAttempt:
                 parent_acs_credential_id=d.get("parent_acs_credential_id", None),
                 starts_at=d.get("starts_at", None),
                 user_identity_id=d.get("user_identity_id", None),
-                visionline_metadata=(
-                    cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                    if d.get("visionline_metadata") is not None
-                    else None
+                visionline_metadata=_object_from_dict(
+                    cls.VisionlineMetadata, d.get("visionline_metadata")
                 ),
-                warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+                warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
                 workspace_id=d.get("workspace_id", None),
             )
 
@@ -1194,11 +1235,13 @@ class EncodeCredentialSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -1225,6 +1268,8 @@ class EncodeCredentialPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -1273,6 +1318,8 @@ class EncodeCredentialErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -1286,10 +1333,12 @@ class EncodeCredentialErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -1382,6 +1431,8 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     member_pin_id=d.get("member_pin_id", None),
                 )
@@ -1412,6 +1463,8 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     auto_join=d.get("auto_join", None),
                     door_names=d.get("door_names", None),
@@ -1439,6 +1492,8 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     error_code=d.get("error_code", None),
@@ -1477,6 +1532,8 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     auto_join=d.get("auto_join", None),
                     card_function_type=d.get("card_function_type", None),
@@ -1519,6 +1576,8 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     message=d.get("message", None),
@@ -1576,23 +1635,19 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method=d.get("access_method", None),
                 acs_credential_id=d.get("acs_credential_id", None),
                 acs_credential_pool_id=d.get("acs_credential_pool_id", None),
                 acs_system_id=d.get("acs_system_id", None),
                 acs_user_id=d.get("acs_user_id", None),
-                akiles_metadata=(
-                    cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                    if d.get("akiles_metadata") is not None
-                    else None
+                akiles_metadata=_object_from_dict(
+                    cls.AkilesMetadata, d.get("akiles_metadata")
                 ),
-                assa_abloy_vostio_metadata=(
-                    cls.AssaAbloyVostioMetadata.from_dict(
-                        d.get("assa_abloy_vostio_metadata")
-                    )
-                    if d.get("assa_abloy_vostio_metadata") is not None
-                    else None
+                assa_abloy_vostio_metadata=_object_from_dict(
+                    cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
                 ),
                 card_number=d.get("card_number", None),
                 code=d.get("code", None),
@@ -1600,7 +1655,7 @@ class ScanToAssignCredentialSuccessActionAttempt:
                 created_at=d.get("created_at", None),
                 display_name=d.get("display_name", None),
                 ends_at=d.get("ends_at", None),
-                errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+                errors=_object_list_from_dict(cls.Errors, d.get("errors")),
                 external_type=d.get("external_type", None),
                 external_type_display_name=d.get("external_type_display_name", None),
                 is_issued=d.get("is_issued", None),
@@ -1619,12 +1674,10 @@ class ScanToAssignCredentialSuccessActionAttempt:
                 parent_acs_credential_id=d.get("parent_acs_credential_id", None),
                 starts_at=d.get("starts_at", None),
                 user_identity_id=d.get("user_identity_id", None),
-                visionline_metadata=(
-                    cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                    if d.get("visionline_metadata") is not None
-                    else None
+                visionline_metadata=_object_from_dict(
+                    cls.VisionlineMetadata, d.get("visionline_metadata")
                 ),
-                warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+                warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
                 workspace_id=d.get("workspace_id", None),
             )
 
@@ -1636,11 +1689,13 @@ class ScanToAssignCredentialSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -1667,6 +1722,8 @@ class ScanToAssignCredentialPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -1706,6 +1763,8 @@ class ScanToAssignCredentialErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -1719,10 +1778,12 @@ class ScanToAssignCredentialErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -1802,6 +1863,8 @@ class AssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     error_code=d.get("error_code", None),
@@ -1835,6 +1898,8 @@ class AssignCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         ends_at=d.get("ends_at", None),
                         starts_at=d.get("starts_at", None),
@@ -1853,6 +1918,8 @@ class AssignCredentialSuccessActionAttempt:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         ends_at=d.get("ends_at", None),
                         starts_at=d.get("starts_at", None),
@@ -1868,20 +1935,14 @@ class AssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
-                    from_=(
-                        cls.From.from_dict(d.get("from"))
-                        if d.get("from") is not None
-                        else None
-                    ),
+                    from_=_object_from_dict(cls.From, d.get("from")),
                     message=d.get("message", None),
                     mutation_code=d.get("mutation_code", None),
-                    to=(
-                        cls.To.from_dict(d.get("to"))
-                        if d.get("to") is not None
-                        else None
-                    ),
+                    to=_object_from_dict(cls.To, d.get("to")),
                 )
 
         @dataclass
@@ -1909,6 +1970,8 @@ class AssignCredentialSuccessActionAttempt:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     message=d.get("message", None),
@@ -1938,6 +2001,8 @@ class AssignCredentialSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method_id=d.get("access_method_id", None),
                 client_session_token=d.get("client_session_token", None),
@@ -1946,7 +2011,7 @@ class AssignCredentialSuccessActionAttempt:
                 customization_profile_id=d.get("customization_profile_id", None),
                 display_name=d.get("display_name", None),
                 display_status=d.get("display_status", None),
-                errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+                errors=_object_list_from_dict(cls.Errors, d.get("errors")),
                 instant_key_url=d.get("instant_key_url", None),
                 is_assignment_required=d.get("is_assignment_required", None),
                 is_encoding_required=d.get("is_encoding_required", None),
@@ -1955,11 +2020,10 @@ class AssignCredentialSuccessActionAttempt:
                 is_ready_for_encoding=d.get("is_ready_for_encoding", None),
                 issued_at=d.get("issued_at", None),
                 mode=d.get("mode", None),
-                pending_mutations=[
-                    cls.PendingMutations.from_dict(i)
-                    for i in d.get("pending_mutations") or []
-                ],
-                warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+                pending_mutations=_object_list_from_dict(
+                    cls.PendingMutations, d.get("pending_mutations")
+                ),
+                warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
                 workspace_id=d.get("workspace_id", None),
             )
 
@@ -1971,11 +2035,13 @@ class AssignCredentialSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2002,6 +2068,8 @@ class AssignCredentialPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2040,6 +2108,8 @@ class AssignCredentialErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2053,10 +2123,12 @@ class AssignCredentialErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2083,6 +2155,8 @@ class ResetSandboxWorkspaceSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2093,11 +2167,13 @@ class ResetSandboxWorkspaceSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2124,6 +2200,8 @@ class ResetSandboxWorkspacePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2160,6 +2238,8 @@ class ResetSandboxWorkspaceErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2173,10 +2253,12 @@ class ResetSandboxWorkspaceErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2203,6 +2285,8 @@ class SetFanModeSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2213,11 +2297,13 @@ class SetFanModeSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2244,6 +2330,8 @@ class SetFanModePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2280,6 +2368,8 @@ class SetFanModeErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2293,10 +2383,12 @@ class SetFanModeErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2323,6 +2415,8 @@ class SetHvacModeSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2333,11 +2427,13 @@ class SetHvacModeSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2364,6 +2460,8 @@ class SetHvacModePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2400,6 +2498,8 @@ class SetHvacModeErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2413,10 +2513,12 @@ class SetHvacModeErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2443,6 +2545,8 @@ class ActivateClimatePresetSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2453,11 +2557,13 @@ class ActivateClimatePresetSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2484,6 +2590,8 @@ class ActivateClimatePresetPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2520,6 +2628,8 @@ class ActivateClimatePresetErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2533,10 +2643,12 @@ class ActivateClimatePresetErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2563,6 +2675,8 @@ class SimulateKeypadCodeEntrySuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2573,11 +2687,13 @@ class SimulateKeypadCodeEntrySuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2604,6 +2720,8 @@ class SimulateKeypadCodeEntryPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2640,6 +2758,8 @@ class SimulateKeypadCodeEntryErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2653,10 +2773,12 @@ class SimulateKeypadCodeEntryErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2683,6 +2805,8 @@ class SimulateManualLockViaKeypadSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2693,11 +2817,13 @@ class SimulateManualLockViaKeypadSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2724,6 +2850,8 @@ class SimulateManualLockViaKeypadPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2760,6 +2888,8 @@ class SimulateManualLockViaKeypadErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2773,10 +2903,12 @@ class SimulateManualLockViaKeypadErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2803,6 +2935,8 @@ class PushThermostatProgramsSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2813,11 +2947,13 @@ class PushThermostatProgramsSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2844,6 +2980,8 @@ class PushThermostatProgramsPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -2880,6 +3018,8 @@ class PushThermostatProgramsErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -2893,10 +3033,12 @@ class PushThermostatProgramsErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -2923,6 +3065,8 @@ class ConfigureAutoLockSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -2933,11 +3077,13 @@ class ConfigureAutoLockSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -2964,6 +3110,8 @@ class ConfigureAutoLockPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3000,6 +3148,8 @@ class ConfigureAutoLockErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3013,10 +3163,12 @@ class ConfigureAutoLockErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3043,6 +3195,8 @@ class SyncAccessCodesSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -3053,11 +3207,13 @@ class SyncAccessCodesSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3084,6 +3240,8 @@ class SyncAccessCodesPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3120,6 +3278,8 @@ class SyncAccessCodesErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3133,10 +3293,12 @@ class SyncAccessCodesErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3166,8 +3328,10 @@ class CreateAccessCodeSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                access_code=DeepAttrDict(d.get("access_code", None)),
+                access_code=_record_from_dict(d.get("access_code", None)),
             )
 
     action_attempt_id: str
@@ -3178,11 +3342,13 @@ class CreateAccessCodeSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3209,6 +3375,8 @@ class CreateAccessCodePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3245,6 +3413,8 @@ class CreateAccessCodeErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3258,10 +3428,12 @@ class CreateAccessCodeErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3288,6 +3460,8 @@ class DeleteAccessCodeSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -3298,11 +3472,13 @@ class DeleteAccessCodeSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3329,6 +3505,8 @@ class DeleteAccessCodePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3365,6 +3543,8 @@ class DeleteAccessCodeErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3378,10 +3558,12 @@ class DeleteAccessCodeErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3411,8 +3593,10 @@ class UpdateAccessCodeSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                access_code=DeepAttrDict(d.get("access_code", None)),
+                access_code=_record_from_dict(d.get("access_code", None)),
             )
 
     action_attempt_id: str
@@ -3423,11 +3607,13 @@ class UpdateAccessCodeSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3454,6 +3640,8 @@ class UpdateAccessCodePendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3490,6 +3678,8 @@ class UpdateAccessCodeErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3503,10 +3693,12 @@ class UpdateAccessCodeErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3536,8 +3728,10 @@ class CreateNoiseThresholdSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                noise_threshold=DeepAttrDict(d.get("noise_threshold", None)),
+                noise_threshold=_record_from_dict(d.get("noise_threshold", None)),
             )
 
     action_attempt_id: str
@@ -3548,11 +3742,13 @@ class CreateNoiseThresholdSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3579,6 +3775,8 @@ class CreateNoiseThresholdPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3615,6 +3813,8 @@ class CreateNoiseThresholdErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3628,10 +3828,12 @@ class CreateNoiseThresholdErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3658,6 +3860,8 @@ class DeleteNoiseThresholdSuccessActionAttempt:
         @classmethod
         def from_dict(cls, d: Any):
             # pylint: disable=unused-argument
+            if not isinstance(d, dict):
+                d = {}
             return cls()
 
     action_attempt_id: str
@@ -3668,11 +3872,13 @@ class DeleteNoiseThresholdSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3699,6 +3905,8 @@ class DeleteNoiseThresholdPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3735,6 +3943,8 @@ class DeleteNoiseThresholdErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3748,10 +3958,12 @@ class DeleteNoiseThresholdErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -3781,8 +3993,10 @@ class UpdateNoiseThresholdSuccessActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                noise_threshold=DeepAttrDict(d.get("noise_threshold", None)),
+                noise_threshold=_record_from_dict(d.get("noise_threshold", None)),
             )
 
     action_attempt_id: str
@@ -3793,11 +4007,13 @@ class UpdateNoiseThresholdSuccessActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
             error=d.get("error", None),
-            result=cls.Result.from_dict(d.get("result") or {}),
+            result=_required_object_from_dict(cls.Result, d.get("result")),
             status=d.get("status", None),
         )
 
@@ -3824,6 +4040,8 @@ class UpdateNoiseThresholdPendingActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -3860,6 +4078,8 @@ class UpdateNoiseThresholdErrorActionAttempt:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 type=d.get("type", None),
@@ -3873,10 +4093,12 @@ class UpdateNoiseThresholdErrorActionAttempt:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
-            error=cls.Error.from_dict(d.get("error") or {}),
+            error=_required_object_from_dict(cls.Error, d.get("error")),
             result=d.get("result", None),
             status=d.get("status", None),
         )
@@ -4237,10 +4459,22 @@ _ACTION_ATTEMPT_VARIANTS: Dict[Tuple[str, str], Any] = {
 def action_attempt_from_dict(d: Any) -> ActionAttempt:
     """Deserialize a known action_type and status variant.
 
-    Unknown discriminator values return ``DeepAttrDict`` so payloads from a
-    newer API remain readable. The static return type covers known variants.
+    An unrecognized discriminator, or a known one whose payload does not
+    convert, returns ``DeepAttrDict`` so payloads from a newer API remain
+    readable. The static return type covers known variants.
     """
-    variant = _ACTION_ATTEMPT_VARIANTS.get((d.get("action_type"), d.get("status")))
+    if not isinstance(d, dict):
+        return cast(ActionAttempt, DeepAttrDict(d) if isinstance(d, dict) else d)
+    key = (d.get("action_type"), d.get("status"))
+    variant = (
+        _ACTION_ATTEMPT_VARIANTS.get(cast(Tuple[str, str], key))
+        if isinstance(key[0], str) and isinstance(key[1], str)
+        else None
+    )
     if variant is None:
         return cast(ActionAttempt, DeepAttrDict(d))
-    return variant.from_dict(d)
+    try:
+        return variant.from_dict(d)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # A known discriminator whose payload does not convert is still readable.
+        return cast(ActionAttempt, DeepAttrDict(d))

--- a/seam/resources/batch.py
+++ b/seam/resources/batch.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -161,6 +168,8 @@ class Batch:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_codes=d.get("access_codes", None),
             access_grants=d.get("access_grants", None),

--- a/seam/resources/client_session.py
+++ b/seam/resources/client_session.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -55,6 +62,8 @@ class ClientSession:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             client_session_id=d.get("client_session_id", None),
             connect_webview_ids=d.get("connect_webview_ids", None),

--- a/seam/resources/connect_webview.py
+++ b/seam/resources/connect_webview.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -80,6 +87,8 @@ class ConnectWebview:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             accepted_capabilities=d.get("accepted_capabilities", None),
             accepted_providers=d.get("accepted_providers", None),
@@ -91,7 +100,7 @@ class ConnectWebview:
             connect_webview_id=d.get("connect_webview_id", None),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            custom_metadata=DeepAttrDict(d.get("custom_metadata", None)),
+            custom_metadata=_record_from_dict(d.get("custom_metadata", None)),
             custom_redirect_failure_url=d.get("custom_redirect_failure_url", None),
             custom_redirect_url=d.get("custom_redirect_url", None),
             customer_key=d.get("customer_key", None),

--- a/seam/resources/connected_account.py
+++ b/seam/resources/connected_account.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -74,6 +74,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -105,6 +107,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -157,6 +161,8 @@ class ConnectedAccount:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         site_id=d.get("site_id", None),
                         site_name=d.get("site_name", None),
@@ -172,8 +178,10 @@ class ConnectedAccount:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    sites=[cls.Sites.from_dict(i) for i in d.get("sites") or []],
+                    sites=_object_list_from_dict(cls.Sites, d.get("sites")),
                 )
 
         created_at: str
@@ -185,16 +193,16 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
                 is_bridge_error=d.get("is_bridge_error", None),
                 is_connected_account_error=d.get("is_connected_account_error", None),
                 message=d.get("message", None),
-                salto_ks_metadata=(
-                    cls.SaltoKsMetadata.from_dict(d.get("salto_ks_metadata"))
-                    if d.get("salto_ks_metadata") is not None
-                    else None
+                salto_ks_metadata=_object_from_dict(
+                    cls.SaltoKsMetadata, d.get("salto_ks_metadata")
                 ),
             )
 
@@ -221,6 +229,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -252,6 +262,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 api_url=d.get("api_url", None),
                 email=d.get("email", None),
@@ -277,6 +289,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -300,6 +314,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -346,6 +362,8 @@ class ConnectedAccount:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         site_id=d.get("site_id", None),
                         site_name=d.get("site_name", None),
@@ -361,8 +379,10 @@ class ConnectedAccount:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    sites=[cls.Sites.from_dict(i) for i in d.get("sites") or []],
+                    sites=_object_list_from_dict(cls.Sites, d.get("sites")),
                 )
 
         created_at: str
@@ -372,13 +392,13 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
-                salto_ks_metadata=(
-                    cls.SaltoKsMetadata.from_dict(d.get("salto_ks_metadata"))
-                    if d.get("salto_ks_metadata") is not None
-                    else None
+                salto_ks_metadata=_object_from_dict(
+                    cls.SaltoKsMetadata, d.get("salto_ks_metadata")
                 ),
                 warning_code=d.get("warning_code", None),
             )
@@ -400,6 +420,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -423,6 +445,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -446,6 +470,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -469,6 +495,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -492,6 +520,8 @@ class ConnectedAccount:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -555,6 +585,8 @@ class ConnectedAccount:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             accepted_capabilities=d.get("accepted_capabilities", None),
             account_type=d.get("account_type", None),
@@ -564,26 +596,22 @@ class ConnectedAccount:
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            custom_metadata=DeepAttrDict(d.get("custom_metadata", None)),
+            custom_metadata=_record_from_dict(d.get("custom_metadata", None)),
             customer_key=d.get("customer_key", None),
             default_checkin_time=d.get("default_checkin_time", None),
             default_checkout_time=d.get("default_checkout_time", None),
             display_name=d.get("display_name", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             ical_feed_origin=d.get("ical_feed_origin", None),
             ical_url=d.get("ical_url", None),
             image_url=d.get("image_url", None),
             time_zone=d.get("time_zone", None),
-            user_identifier=(
-                cls.UserIdentifier.from_dict(d.get("user_identifier"))
-                if d.get("user_identifier") is not None
-                else None
+            user_identifier=_object_from_dict(
+                cls.UserIdentifier, d.get("user_identifier")
             ),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
         )

--- a/seam/resources/customer_portal.py
+++ b/seam/resources/customer_portal.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -30,6 +37,8 @@ class CustomerPortal:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),

--- a/seam/resources/device.py
+++ b/seam/resources/device.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -107,6 +107,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 display_name=d.get("display_name", None),
                 image_url=d.get("image_url", None),
@@ -133,6 +135,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 device_provider_name=d.get("device_provider_name", None),
                 display_name=d.get("display_name", None),
@@ -163,6 +167,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -194,6 +200,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -225,6 +233,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -256,6 +266,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -284,6 +296,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -311,6 +325,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -338,6 +354,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -365,6 +383,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -392,6 +412,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -419,6 +441,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -446,6 +470,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -473,6 +499,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -500,6 +528,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -530,6 +560,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -558,6 +590,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 location_name=d.get("location_name", None),
                 room_name=d.get("room_name", None),
@@ -799,6 +833,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         level=d.get("level", None),
                     )
@@ -808,12 +844,10 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    battery=(
-                        cls.Battery.from_dict(d.get("battery"))
-                        if d.get("battery") is not None
-                        else None
-                    ),
+                    battery=_object_from_dict(cls.Battery, d.get("battery")),
                     is_connected=d.get("is_connected", None),
                 )
 
@@ -828,6 +862,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     name=d.get("name", None),
                 )
@@ -846,6 +882,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     level=d.get("level", None),
                     status=d.get("status", None),
@@ -880,6 +918,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     accessory_keypad_supported=d.get(
                         "accessory_keypad_supported", None
@@ -920,6 +960,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         endpoint_id=d.get("endpoint_id", None),
                         is_active=d.get("is_active", None),
@@ -930,10 +972,10 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    endpoints=[
-                        cls.Endpoints.from_dict(i) for i in d.get("endpoints") or []
-                    ],
+                    endpoints=_object_list_from_dict(cls.Endpoints, d.get("endpoints")),
                     has_active_endpoint=d.get("has_active_endpoint", None),
                 )
 
@@ -948,6 +990,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     has_active_phone=d.get("has_active_phone", None),
                 )
@@ -971,6 +1015,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     _member_group_id=d.get("_member_group_id", None),
                     gadget_id=d.get("gadget_id", None),
@@ -1009,6 +1055,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_name=d.get("device_name", None),
                     did=d.get("did", None),
@@ -1030,6 +1078,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     encoder_name=d.get("encoder_name", None),
                 )
@@ -1062,6 +1112,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     has_keypad=d.get("has_keypad", None),
                     house_id=d.get("house_id", None),
@@ -1100,6 +1152,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     entry_name=d.get("entry_name", None),
                     entry_relays_total_count=d.get("entry_relays_total_count", None),
@@ -1123,6 +1177,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     activation_enabled=d.get("activation_enabled", None),
                     device_name=d.get("device_name", None),
@@ -1144,6 +1200,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1207,6 +1265,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         check_in_time=d.get("check_in_time", None),
                         check_out_time=d.get("check_out_time", None),
@@ -1235,16 +1295,17 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     door_id=d.get("door_id", None),
                     door_is_wireless=d.get("door_is_wireless", None),
                     door_name=d.get("door_name", None),
                     iana_timezone=d.get("iana_timezone", None),
-                    predefined_time_slots=[
-                        cls.PredefinedTimeSlots.from_dict(i)
-                        for i in d.get("predefined_time_slots") or []
-                    ],
+                    predefined_time_slots=_object_list_from_dict(
+                        cls.PredefinedTimeSlots, d.get("predefined_time_slots")
+                    ),
                     site_id=d.get("site_id", None),
                     site_name=d.get("site_name", None),
                 )
@@ -1262,6 +1323,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_name=d.get("device_name", None),
                     ecobee_device_id=d.get("ecobee_device_id", None),
@@ -1284,6 +1347,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1303,6 +1368,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_name=d.get("device_name", None),
                     door_name=d.get("door_name", None),
@@ -1322,6 +1389,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_name=d.get("device_name", None),
                     honeywell_resideo_device_id=d.get(
@@ -1345,6 +1414,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     bridge_id=d.get("bridge_id", None),
                     device_id=d.get("device_id", None),
@@ -1376,6 +1447,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     bridge_id=d.get("bridge_id", None),
                     bridge_name=d.get("bridge_name", None),
@@ -1457,6 +1530,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     address=d.get("address", None),
                     current_or_last_store_id=d.get("current_or_last_store_id", None),
@@ -1500,6 +1575,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     description=d.get("description", None),
                     lock_id=d.get("lock_id", None),
@@ -1536,6 +1613,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1562,6 +1641,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1584,6 +1665,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1628,6 +1711,8 @@ class Device:
 
                     @classmethod
                     def from_dict(cls, d: Any):
+                        if not isinstance(d, dict):
+                            d = {}
                         return cls(
                             time=d.get("time", None),
                             value=d.get("value", None),
@@ -1646,6 +1731,8 @@ class Device:
 
                     @classmethod
                     def from_dict(cls, d: Any):
+                        if not isinstance(d, dict):
+                            d = {}
                         return cls(
                             time=d.get("time", None),
                             value=d.get("value", None),
@@ -1664,6 +1751,8 @@ class Device:
 
                     @classmethod
                     def from_dict(cls, d: Any):
+                        if not isinstance(d, dict):
+                            d = {}
                         return cls(
                             time=d.get("time", None),
                             value=d.get("value", None),
@@ -1682,6 +1771,8 @@ class Device:
 
                     @classmethod
                     def from_dict(cls, d: Any):
+                        if not isinstance(d, dict):
+                            d = {}
                         return cls(
                             time=d.get("time", None),
                             value=d.get("value", None),
@@ -1701,6 +1792,8 @@ class Device:
 
                     @classmethod
                     def from_dict(cls, d: Any):
+                        if not isinstance(d, dict):
+                            d = {}
                         return cls(
                             time=d.get("time", None),
                             value=d.get("value", None),
@@ -1714,31 +1807,17 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
-                        accelerometer_z=(
-                            cls.AccelerometerZ.from_dict(d.get("accelerometer_z"))
-                            if d.get("accelerometer_z") is not None
-                            else None
+                        accelerometer_z=_object_from_dict(
+                            cls.AccelerometerZ, d.get("accelerometer_z")
                         ),
-                        humidity=(
-                            cls.Humidity.from_dict(d.get("humidity"))
-                            if d.get("humidity") is not None
-                            else None
-                        ),
-                        pressure=(
-                            cls.Pressure.from_dict(d.get("pressure"))
-                            if d.get("pressure") is not None
-                            else None
-                        ),
-                        sound=(
-                            cls.Sound.from_dict(d.get("sound"))
-                            if d.get("sound") is not None
-                            else None
-                        ),
-                        temperature=(
-                            cls.Temperature.from_dict(d.get("temperature"))
-                            if d.get("temperature") is not None
-                            else None
+                        humidity=_object_from_dict(cls.Humidity, d.get("humidity")),
+                        pressure=_object_from_dict(cls.Pressure, d.get("pressure")),
+                        sound=_object_from_dict(cls.Sound, d.get("sound")),
+                        temperature=_object_from_dict(
+                            cls.Temperature, d.get("temperature")
                         ),
                     )
 
@@ -1748,13 +1827,13 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
-                    latest_sensor_values=(
-                        cls.LatestSensorValues.from_dict(d.get("latest_sensor_values"))
-                        if d.get("latest_sensor_values") is not None
-                        else None
+                    latest_sensor_values=_object_from_dict(
+                        cls.LatestSensorValues, d.get("latest_sensor_values")
                     ),
                 )
 
@@ -1784,6 +1863,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_custom_name=d.get("device_custom_name", None),
                     device_name=d.get("device_name", None),
@@ -1816,6 +1897,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_model=d.get("device_model", None),
@@ -1847,6 +1930,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1884,6 +1969,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     has_gateway=d.get("has_gateway", None),
                     lock_alias=d.get("lock_alias", None),
@@ -1907,6 +1994,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -1947,6 +2036,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     battery_level=d.get("battery_level", None),
                     customer_reference=d.get("customer_reference", None),
@@ -1993,6 +2084,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     battery_level=d.get("battery_level", None),
                     customer_reference=d.get("customer_reference", None),
@@ -2020,6 +2113,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2042,6 +2137,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_num=d.get("device_num", None),
                     name=d.get("name", None),
@@ -2067,6 +2164,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2095,6 +2194,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2115,6 +2216,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_type=d.get("device_type", None),
                     serial_no=d.get("serial_no", None),
@@ -2148,6 +2251,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     bridge_id=d.get("bridge_id", None),
                     bridge_name=d.get("bridge_name", None),
@@ -2204,6 +2309,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         auto_lock_time_config=d.get("auto_lock_time_config", None),
                         incomplete_keyboard_passcode=d.get(
@@ -2230,6 +2337,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         wireless_keypad_id=d.get("wireless_keypad_id", None),
                         wireless_keypad_name=d.get("wireless_keypad_name", None),
@@ -2245,21 +2354,18 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     feature_value=d.get("feature_value", None),
-                    features=(
-                        cls.Features.from_dict(d.get("features"))
-                        if d.get("features") is not None
-                        else None
-                    ),
+                    features=_object_from_dict(cls.Features, d.get("features")),
                     has_gateway=d.get("has_gateway", None),
                     lock_alias=d.get("lock_alias", None),
                     lock_id=d.get("lock_id", None),
                     timezone_raw_offset_ms=d.get("timezone_raw_offset_ms", None),
-                    wireless_keypads=[
-                        cls.WirelessKeypads.from_dict(i)
-                        for i in d.get("wireless_keypads") or []
-                    ],
+                    wireless_keypads=_object_list_from_dict(
+                        cls.WirelessKeypads, d.get("wireless_keypads")
+                    ),
                 )
 
         @dataclass
@@ -2275,6 +2381,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2299,6 +2407,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2316,6 +2426,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     encoder_id=d.get("encoder_id", None),
                 )
@@ -2351,6 +2463,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_info_model=d.get("device_info_model", None),
@@ -2381,6 +2495,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     device_name=d.get("device_name", None),
@@ -2419,6 +2535,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     constraint_type=d.get("constraint_type", None),
                     max_length=d.get("max_length", None),
@@ -2435,6 +2553,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     level=d.get("level", None),
                 )
@@ -2477,6 +2597,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         display_name=d.get("display_name", None),
                         end_time=d.get("end_time", None),
@@ -2494,6 +2616,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     display_name=d.get("display_name", None),
                     end_date_recurrence_rule=d.get("end_date_recurrence_rule", None),
@@ -2503,9 +2627,9 @@ class Device:
                     start_date_recurrence_rule=d.get(
                         "start_date_recurrence_rule", None
                     ),
-                    time_pairs=[
-                        cls.TimePairs.from_dict(i) for i in d.get("time_pairs") or []
-                    ],
+                    time_pairs=_object_list_from_dict(
+                        cls.TimePairs, d.get("time_pairs")
+                    ),
                     time_zone=d.get("time_zone", None),
                 )
 
@@ -2547,6 +2671,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         display_name=d.get("display_name", None),
                         end_time=d.get("end_time", None),
@@ -2564,6 +2690,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     display_name=d.get("display_name", None),
                     end_date_recurrence_rule=d.get("end_date_recurrence_rule", None),
@@ -2573,9 +2701,9 @@ class Device:
                     start_date_recurrence_rule=d.get(
                         "start_date_recurrence_rule", None
                     ),
-                    time_pairs=[
-                        cls.TimePairs.from_dict(i) for i in d.get("time_pairs") or []
-                    ],
+                    time_pairs=_object_list_from_dict(
+                        cls.TimePairs, d.get("time_pairs")
+                    ),
                     time_zone=d.get("time_zone", None),
                 )
 
@@ -2623,6 +2751,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         created_at=d.get("created_at", None),
                         error_code=d.get("error_code", None),
@@ -2643,12 +2773,14 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     climate_preset_key=d.get("climate_preset_key", None),
                     created_at=d.get("created_at", None),
                     device_id=d.get("device_id", None),
                     ends_at=d.get("ends_at", None),
-                    errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+                    errors=_object_list_from_dict(cls.Errors, d.get("errors")),
                     is_override_allowed=d.get("is_override_allowed", None),
                     max_override_period_minutes=d.get(
                         "max_override_period_minutes", None
@@ -2711,6 +2843,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         climate_ref=d.get("climate_ref", None),
                         is_optimized=d.get("is_optimized", None),
@@ -2739,6 +2873,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     can_delete=d.get("can_delete", None),
                     can_edit=d.get("can_edit", None),
@@ -2752,10 +2888,8 @@ class Device:
                         "cooling_set_point_fahrenheit", None
                     ),
                     display_name=d.get("display_name", None),
-                    ecobee_metadata=(
-                        cls.EcobeeMetadata.from_dict(d.get("ecobee_metadata"))
-                        if d.get("ecobee_metadata") is not None
-                        else None
+                    ecobee_metadata=_object_from_dict(
+                        cls.EcobeeMetadata, d.get("ecobee_metadata")
                     ),
                     fan_mode_setting=d.get("fan_mode_setting", None),
                     heating_set_point_celsius=d.get("heating_set_point_celsius", None),
@@ -2819,6 +2953,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         climate_ref=d.get("climate_ref", None),
                         is_optimized=d.get("is_optimized", None),
@@ -2847,6 +2983,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     can_delete=d.get("can_delete", None),
                     can_edit=d.get("can_edit", None),
@@ -2860,10 +2998,8 @@ class Device:
                         "cooling_set_point_fahrenheit", None
                     ),
                     display_name=d.get("display_name", None),
-                    ecobee_metadata=(
-                        cls.EcobeeMetadata.from_dict(d.get("ecobee_metadata"))
-                        if d.get("ecobee_metadata") is not None
-                        else None
+                    ecobee_metadata=_object_from_dict(
+                        cls.EcobeeMetadata, d.get("ecobee_metadata")
                     ),
                     fan_mode_setting=d.get("fan_mode_setting", None),
                     heating_set_point_celsius=d.get("heating_set_point_celsius", None),
@@ -2927,6 +3063,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         climate_ref=d.get("climate_ref", None),
                         is_optimized=d.get("is_optimized", None),
@@ -2955,6 +3093,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     can_delete=d.get("can_delete", None),
                     can_edit=d.get("can_edit", None),
@@ -2968,10 +3108,8 @@ class Device:
                         "cooling_set_point_fahrenheit", None
                     ),
                     display_name=d.get("display_name", None),
-                    ecobee_metadata=(
-                        cls.EcobeeMetadata.from_dict(d.get("ecobee_metadata"))
-                        if d.get("ecobee_metadata") is not None
-                        else None
+                    ecobee_metadata=_object_from_dict(
+                        cls.EcobeeMetadata, d.get("ecobee_metadata")
                     ),
                     fan_mode_setting=d.get("fan_mode_setting", None),
                     heating_set_point_celsius=d.get("heating_set_point_celsius", None),
@@ -3003,6 +3141,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     lower_limit_celsius=d.get("lower_limit_celsius", None),
                     lower_limit_fahrenheit=d.get("lower_limit_fahrenheit", None),
@@ -3041,6 +3181,8 @@ class Device:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         climate_preset_key=d.get("climate_preset_key", None),
                         starts_at_time=d.get("starts_at_time", None),
@@ -3055,11 +3197,13 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     device_id=d.get("device_id", None),
                     name=d.get("name", None),
-                    periods=[cls.Periods.from_dict(i) for i in d.get("periods") or []],
+                    periods=_object_list_from_dict(cls.Periods, d.get("periods")),
                     thermostat_daily_program_id=d.get(
                         "thermostat_daily_program_id", None
                     ),
@@ -3098,6 +3242,8 @@ class Device:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     created_at=d.get("created_at", None),
                     friday_program_id=d.get("friday_program_id", None),
@@ -3225,22 +3371,14 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                accessory_keypad=(
-                    cls.AccessoryKeypad.from_dict(d.get("accessory_keypad"))
-                    if d.get("accessory_keypad") is not None
-                    else None
+                accessory_keypad=_object_from_dict(
+                    cls.AccessoryKeypad, d.get("accessory_keypad")
                 ),
-                appearance=(
-                    cls.Appearance.from_dict(d.get("appearance"))
-                    if d.get("appearance") is not None
-                    else None
-                ),
-                battery=(
-                    cls.Battery.from_dict(d.get("battery"))
-                    if d.get("battery") is not None
-                    else None
-                ),
+                appearance=_object_from_dict(cls.Appearance, d.get("appearance")),
+                battery=_object_from_dict(cls.Battery, d.get("battery")),
                 battery_level=d.get("battery_level", None),
                 currently_triggering_noise_threshold_ids=d.get(
                     "currently_triggering_noise_threshold_ids", None
@@ -3249,11 +3387,7 @@ class Device:
                 image_alt_text=d.get("image_alt_text", None),
                 image_url=d.get("image_url", None),
                 manufacturer=d.get("manufacturer", None),
-                model=(
-                    cls.Model.from_dict(d.get("model"))
-                    if d.get("model") is not None
-                    else None
-                ),
+                model=_object_from_dict(cls.Model, d.get("model")),
                 name=d.get("name", None),
                 noise_level_decibels=d.get("noise_level_decibels", None),
                 offline_access_codes_enabled=d.get(
@@ -3266,257 +3400,158 @@ class Device:
                 supports_offline_access_codes=d.get(
                     "supports_offline_access_codes", None
                 ),
-                assa_abloy_credential_service_metadata=(
-                    cls.AssaAbloyCredentialServiceMetadata.from_dict(
-                        d.get("assa_abloy_credential_service_metadata")
-                    )
-                    if d.get("assa_abloy_credential_service_metadata") is not None
-                    else None
+                assa_abloy_credential_service_metadata=_object_from_dict(
+                    cls.AssaAbloyCredentialServiceMetadata,
+                    d.get("assa_abloy_credential_service_metadata"),
                 ),
-                salto_space_credential_service_metadata=(
-                    cls.SaltoSpaceCredentialServiceMetadata.from_dict(
-                        d.get("salto_space_credential_service_metadata")
-                    )
-                    if d.get("salto_space_credential_service_metadata") is not None
-                    else None
+                salto_space_credential_service_metadata=_object_from_dict(
+                    cls.SaltoSpaceCredentialServiceMetadata,
+                    d.get("salto_space_credential_service_metadata"),
                 ),
-                akiles_metadata=(
-                    cls.AkilesMetadata.from_dict(d.get("akiles_metadata"))
-                    if d.get("akiles_metadata") is not None
-                    else None
+                akiles_metadata=_object_from_dict(
+                    cls.AkilesMetadata, d.get("akiles_metadata")
                 ),
-                aqara_metadata=(
-                    cls.AqaraMetadata.from_dict(d.get("aqara_metadata"))
-                    if d.get("aqara_metadata") is not None
-                    else None
+                aqara_metadata=_object_from_dict(
+                    cls.AqaraMetadata, d.get("aqara_metadata")
                 ),
-                assa_abloy_vostio_metadata=(
-                    cls.AssaAbloyVostioMetadata.from_dict(
-                        d.get("assa_abloy_vostio_metadata")
-                    )
-                    if d.get("assa_abloy_vostio_metadata") is not None
-                    else None
+                assa_abloy_vostio_metadata=_object_from_dict(
+                    cls.AssaAbloyVostioMetadata, d.get("assa_abloy_vostio_metadata")
                 ),
-                august_metadata=(
-                    cls.AugustMetadata.from_dict(d.get("august_metadata"))
-                    if d.get("august_metadata") is not None
-                    else None
+                august_metadata=_object_from_dict(
+                    cls.AugustMetadata, d.get("august_metadata")
                 ),
-                avigilon_alta_metadata=(
-                    cls.AvigilonAltaMetadata.from_dict(d.get("avigilon_alta_metadata"))
-                    if d.get("avigilon_alta_metadata") is not None
-                    else None
+                avigilon_alta_metadata=_object_from_dict(
+                    cls.AvigilonAltaMetadata, d.get("avigilon_alta_metadata")
                 ),
-                brivo_metadata=(
-                    cls.BrivoMetadata.from_dict(d.get("brivo_metadata"))
-                    if d.get("brivo_metadata") is not None
-                    else None
+                brivo_metadata=_object_from_dict(
+                    cls.BrivoMetadata, d.get("brivo_metadata")
                 ),
-                controlbyweb_metadata=(
-                    cls.ControlbywebMetadata.from_dict(d.get("controlbyweb_metadata"))
-                    if d.get("controlbyweb_metadata") is not None
-                    else None
+                controlbyweb_metadata=_object_from_dict(
+                    cls.ControlbywebMetadata, d.get("controlbyweb_metadata")
                 ),
-                dormakaba_oracode_metadata=(
-                    cls.DormakabaOracodeMetadata.from_dict(
-                        d.get("dormakaba_oracode_metadata")
-                    )
-                    if d.get("dormakaba_oracode_metadata") is not None
-                    else None
+                dormakaba_oracode_metadata=_object_from_dict(
+                    cls.DormakabaOracodeMetadata, d.get("dormakaba_oracode_metadata")
                 ),
-                ecobee_metadata=(
-                    cls.EcobeeMetadata.from_dict(d.get("ecobee_metadata"))
-                    if d.get("ecobee_metadata") is not None
-                    else None
+                ecobee_metadata=_object_from_dict(
+                    cls.EcobeeMetadata, d.get("ecobee_metadata")
                 ),
-                four_suites_metadata=(
-                    cls.FourSuitesMetadata.from_dict(d.get("four_suites_metadata"))
-                    if d.get("four_suites_metadata") is not None
-                    else None
+                four_suites_metadata=_object_from_dict(
+                    cls.FourSuitesMetadata, d.get("four_suites_metadata")
                 ),
-                genie_metadata=(
-                    cls.GenieMetadata.from_dict(d.get("genie_metadata"))
-                    if d.get("genie_metadata") is not None
-                    else None
+                genie_metadata=_object_from_dict(
+                    cls.GenieMetadata, d.get("genie_metadata")
                 ),
-                honeywell_resideo_metadata=(
-                    cls.HoneywellResideoMetadata.from_dict(
-                        d.get("honeywell_resideo_metadata")
-                    )
-                    if d.get("honeywell_resideo_metadata") is not None
-                    else None
+                honeywell_resideo_metadata=_object_from_dict(
+                    cls.HoneywellResideoMetadata, d.get("honeywell_resideo_metadata")
                 ),
-                igloo_metadata=(
-                    cls.IglooMetadata.from_dict(d.get("igloo_metadata"))
-                    if d.get("igloo_metadata") is not None
-                    else None
+                igloo_metadata=_object_from_dict(
+                    cls.IglooMetadata, d.get("igloo_metadata")
                 ),
-                igloohome_metadata=(
-                    cls.IgloohomeMetadata.from_dict(d.get("igloohome_metadata"))
-                    if d.get("igloohome_metadata") is not None
-                    else None
+                igloohome_metadata=_object_from_dict(
+                    cls.IgloohomeMetadata, d.get("igloohome_metadata")
                 ),
-                keynest_metadata=(
-                    cls.KeynestMetadata.from_dict(d.get("keynest_metadata"))
-                    if d.get("keynest_metadata") is not None
-                    else None
+                keynest_metadata=_object_from_dict(
+                    cls.KeynestMetadata, d.get("keynest_metadata")
                 ),
-                kisi_metadata=(
-                    cls.KisiMetadata.from_dict(d.get("kisi_metadata"))
-                    if d.get("kisi_metadata") is not None
-                    else None
+                kisi_metadata=_object_from_dict(
+                    cls.KisiMetadata, d.get("kisi_metadata")
                 ),
-                korelock_metadata=(
-                    cls.KorelockMetadata.from_dict(d.get("korelock_metadata"))
-                    if d.get("korelock_metadata") is not None
-                    else None
+                korelock_metadata=_object_from_dict(
+                    cls.KorelockMetadata, d.get("korelock_metadata")
                 ),
-                kwikset_metadata=(
-                    cls.KwiksetMetadata.from_dict(d.get("kwikset_metadata"))
-                    if d.get("kwikset_metadata") is not None
-                    else None
+                kwikset_metadata=_object_from_dict(
+                    cls.KwiksetMetadata, d.get("kwikset_metadata")
                 ),
-                lockly_metadata=(
-                    cls.LocklyMetadata.from_dict(d.get("lockly_metadata"))
-                    if d.get("lockly_metadata") is not None
-                    else None
+                lockly_metadata=_object_from_dict(
+                    cls.LocklyMetadata, d.get("lockly_metadata")
                 ),
-                minut_metadata=(
-                    cls.MinutMetadata.from_dict(d.get("minut_metadata"))
-                    if d.get("minut_metadata") is not None
-                    else None
+                minut_metadata=_object_from_dict(
+                    cls.MinutMetadata, d.get("minut_metadata")
                 ),
-                nest_metadata=(
-                    cls.NestMetadata.from_dict(d.get("nest_metadata"))
-                    if d.get("nest_metadata") is not None
-                    else None
+                nest_metadata=_object_from_dict(
+                    cls.NestMetadata, d.get("nest_metadata")
                 ),
-                noiseaware_metadata=(
-                    cls.NoiseawareMetadata.from_dict(d.get("noiseaware_metadata"))
-                    if d.get("noiseaware_metadata") is not None
-                    else None
+                noiseaware_metadata=_object_from_dict(
+                    cls.NoiseawareMetadata, d.get("noiseaware_metadata")
                 ),
-                nuki_metadata=(
-                    cls.NukiMetadata.from_dict(d.get("nuki_metadata"))
-                    if d.get("nuki_metadata") is not None
-                    else None
+                nuki_metadata=_object_from_dict(
+                    cls.NukiMetadata, d.get("nuki_metadata")
                 ),
-                omnitec_metadata=(
-                    cls.OmnitecMetadata.from_dict(d.get("omnitec_metadata"))
-                    if d.get("omnitec_metadata") is not None
-                    else None
+                omnitec_metadata=_object_from_dict(
+                    cls.OmnitecMetadata, d.get("omnitec_metadata")
                 ),
-                ring_metadata=(
-                    cls.RingMetadata.from_dict(d.get("ring_metadata"))
-                    if d.get("ring_metadata") is not None
-                    else None
+                ring_metadata=_object_from_dict(
+                    cls.RingMetadata, d.get("ring_metadata")
                 ),
-                salto_ks_metadata=(
-                    cls.SaltoKsMetadata.from_dict(d.get("salto_ks_metadata"))
-                    if d.get("salto_ks_metadata") is not None
-                    else None
+                salto_ks_metadata=_object_from_dict(
+                    cls.SaltoKsMetadata, d.get("salto_ks_metadata")
                 ),
-                salto_metadata=(
-                    cls.SaltoMetadata.from_dict(d.get("salto_metadata"))
-                    if d.get("salto_metadata") is not None
-                    else None
+                salto_metadata=_object_from_dict(
+                    cls.SaltoMetadata, d.get("salto_metadata")
                 ),
-                schlage_metadata=(
-                    cls.SchlageMetadata.from_dict(d.get("schlage_metadata"))
-                    if d.get("schlage_metadata") is not None
-                    else None
+                schlage_metadata=_object_from_dict(
+                    cls.SchlageMetadata, d.get("schlage_metadata")
                 ),
-                seam_bridge_metadata=(
-                    cls.SeamBridgeMetadata.from_dict(d.get("seam_bridge_metadata"))
-                    if d.get("seam_bridge_metadata") is not None
-                    else None
+                seam_bridge_metadata=_object_from_dict(
+                    cls.SeamBridgeMetadata, d.get("seam_bridge_metadata")
                 ),
-                sensi_metadata=(
-                    cls.SensiMetadata.from_dict(d.get("sensi_metadata"))
-                    if d.get("sensi_metadata") is not None
-                    else None
+                sensi_metadata=_object_from_dict(
+                    cls.SensiMetadata, d.get("sensi_metadata")
                 ),
-                smartthings_metadata=(
-                    cls.SmartthingsMetadata.from_dict(d.get("smartthings_metadata"))
-                    if d.get("smartthings_metadata") is not None
-                    else None
+                smartthings_metadata=_object_from_dict(
+                    cls.SmartthingsMetadata, d.get("smartthings_metadata")
                 ),
-                tado_metadata=(
-                    cls.TadoMetadata.from_dict(d.get("tado_metadata"))
-                    if d.get("tado_metadata") is not None
-                    else None
+                tado_metadata=_object_from_dict(
+                    cls.TadoMetadata, d.get("tado_metadata")
                 ),
-                tedee_metadata=(
-                    cls.TedeeMetadata.from_dict(d.get("tedee_metadata"))
-                    if d.get("tedee_metadata") is not None
-                    else None
+                tedee_metadata=_object_from_dict(
+                    cls.TedeeMetadata, d.get("tedee_metadata")
                 ),
-                ttlock_metadata=(
-                    cls.TtlockMetadata.from_dict(d.get("ttlock_metadata"))
-                    if d.get("ttlock_metadata") is not None
-                    else None
+                ttlock_metadata=_object_from_dict(
+                    cls.TtlockMetadata, d.get("ttlock_metadata")
                 ),
-                two_n_metadata=(
-                    cls.TwoNMetadata.from_dict(d.get("two_n_metadata"))
-                    if d.get("two_n_metadata") is not None
-                    else None
+                two_n_metadata=_object_from_dict(
+                    cls.TwoNMetadata, d.get("two_n_metadata")
                 ),
-                ultraloq_metadata=(
-                    cls.UltraloqMetadata.from_dict(d.get("ultraloq_metadata"))
-                    if d.get("ultraloq_metadata") is not None
-                    else None
+                ultraloq_metadata=_object_from_dict(
+                    cls.UltraloqMetadata, d.get("ultraloq_metadata")
                 ),
-                visionline_metadata=(
-                    cls.VisionlineMetadata.from_dict(d.get("visionline_metadata"))
-                    if d.get("visionline_metadata") is not None
-                    else None
+                visionline_metadata=_object_from_dict(
+                    cls.VisionlineMetadata, d.get("visionline_metadata")
                 ),
-                wyze_metadata=(
-                    cls.WyzeMetadata.from_dict(d.get("wyze_metadata"))
-                    if d.get("wyze_metadata") is not None
-                    else None
+                wyze_metadata=_object_from_dict(
+                    cls.WyzeMetadata, d.get("wyze_metadata")
                 ),
-                yacan_metadata=(
-                    cls.YacanMetadata.from_dict(d.get("yacan_metadata"))
-                    if d.get("yacan_metadata") is not None
-                    else None
+                yacan_metadata=_object_from_dict(
+                    cls.YacanMetadata, d.get("yacan_metadata")
                 ),
                 auto_lock_delay_seconds=d.get("auto_lock_delay_seconds", None),
                 auto_lock_enabled=d.get("auto_lock_enabled", None),
                 backup_access_code_pool_enabled=d.get(
                     "backup_access_code_pool_enabled", None
                 ),
-                code_constraints=[
-                    cls.CodeConstraints.from_dict(i)
-                    for i in d.get("code_constraints") or []
-                ],
+                code_constraints=_object_list_from_dict(
+                    cls.CodeConstraints, d.get("code_constraints")
+                ),
                 door_open=d.get("door_open", None),
                 has_native_entry_events=d.get("has_native_entry_events", None),
-                keypad_battery=(
-                    cls.KeypadBattery.from_dict(d.get("keypad_battery"))
-                    if d.get("keypad_battery") is not None
-                    else None
+                keypad_battery=_object_from_dict(
+                    cls.KeypadBattery, d.get("keypad_battery")
                 ),
                 locked=d.get("locked", None),
                 max_active_codes_supported=d.get("max_active_codes_supported", None),
-                offline_time_frame_options=[
-                    cls.OfflineTimeFrameOptions.from_dict(i)
-                    for i in d.get("offline_time_frame_options") or []
-                ],
-                online_time_frame_options=[
-                    cls.OnlineTimeFrameOptions.from_dict(i)
-                    for i in d.get("online_time_frame_options") or []
-                ],
+                offline_time_frame_options=_object_list_from_dict(
+                    cls.OfflineTimeFrameOptions, d.get("offline_time_frame_options")
+                ),
+                online_time_frame_options=_object_list_from_dict(
+                    cls.OnlineTimeFrameOptions, d.get("online_time_frame_options")
+                ),
                 supported_code_lengths=d.get("supported_code_lengths", None),
                 supports_backup_access_code_pool=d.get(
                     "supports_backup_access_code_pool", None
                 ),
-                active_thermostat_schedule=(
-                    cls.ActiveThermostatSchedule.from_dict(
-                        d.get("active_thermostat_schedule")
-                    )
-                    if d.get("active_thermostat_schedule") is not None
-                    else None
+                active_thermostat_schedule=_object_from_dict(
+                    cls.ActiveThermostatSchedule, d.get("active_thermostat_schedule")
                 ),
                 active_thermostat_schedule_id=d.get(
                     "active_thermostat_schedule_id", None
@@ -3524,27 +3559,18 @@ class Device:
                 available_climate_preset_modes=d.get(
                     "available_climate_preset_modes", None
                 ),
-                available_climate_presets=[
-                    cls.AvailableClimatePresets.from_dict(i)
-                    for i in d.get("available_climate_presets") or []
-                ],
+                available_climate_presets=_object_list_from_dict(
+                    cls.AvailableClimatePresets, d.get("available_climate_presets")
+                ),
                 available_fan_mode_settings=d.get("available_fan_mode_settings", None),
                 available_hvac_mode_settings=d.get(
                     "available_hvac_mode_settings", None
                 ),
-                current_climate_setting=(
-                    cls.CurrentClimateSetting.from_dict(
-                        d.get("current_climate_setting")
-                    )
-                    if d.get("current_climate_setting") is not None
-                    else None
+                current_climate_setting=_object_from_dict(
+                    cls.CurrentClimateSetting, d.get("current_climate_setting")
                 ),
-                default_climate_setting=(
-                    cls.DefaultClimateSetting.from_dict(
-                        d.get("default_climate_setting")
-                    )
-                    if d.get("default_climate_setting") is not None
-                    else None
+                default_climate_setting=_object_from_dict(
+                    cls.DefaultClimateSetting, d.get("default_climate_setting")
                 ),
                 fallback_climate_preset_key=d.get("fallback_climate_preset_key", None),
                 fan_mode_setting=d.get("fan_mode_setting", None),
@@ -3593,24 +3619,17 @@ class Device:
                 relative_humidity=d.get("relative_humidity", None),
                 temperature_celsius=d.get("temperature_celsius", None),
                 temperature_fahrenheit=d.get("temperature_fahrenheit", None),
-                temperature_threshold=(
-                    cls.TemperatureThreshold.from_dict(d.get("temperature_threshold"))
-                    if d.get("temperature_threshold") is not None
-                    else None
+                temperature_threshold=_object_from_dict(
+                    cls.TemperatureThreshold, d.get("temperature_threshold")
                 ),
                 thermostat_daily_program_period_precision_minutes=d.get(
                     "thermostat_daily_program_period_precision_minutes", None
                 ),
-                thermostat_daily_programs=[
-                    cls.ThermostatDailyPrograms.from_dict(i)
-                    for i in d.get("thermostat_daily_programs") or []
-                ],
-                thermostat_weekly_program=(
-                    cls.ThermostatWeeklyProgram.from_dict(
-                        d.get("thermostat_weekly_program")
-                    )
-                    if d.get("thermostat_weekly_program") is not None
-                    else None
+                thermostat_daily_programs=_object_list_from_dict(
+                    cls.ThermostatDailyPrograms, d.get("thermostat_daily_programs")
+                ),
+                thermostat_weekly_program=_object_from_dict(
+                    cls.ThermostatWeeklyProgram, d.get("thermostat_weekly_program")
                 ),
             )
 
@@ -3631,6 +3650,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3654,6 +3675,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3677,6 +3700,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3700,6 +3725,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3723,6 +3750,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3746,6 +3775,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3769,6 +3800,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3792,6 +3825,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3815,6 +3850,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3838,6 +3875,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3861,6 +3900,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3884,6 +3925,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3907,6 +3950,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3930,6 +3975,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3953,6 +4000,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3976,6 +4025,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3999,6 +4050,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4022,6 +4075,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4045,6 +4100,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4068,6 +4125,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4091,6 +4150,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4114,6 +4175,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4137,6 +4200,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4160,6 +4225,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4183,6 +4250,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4206,6 +4275,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4229,6 +4300,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4258,6 +4331,8 @@ class Device:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 active_access_code_count=d.get("active_access_code_count", None),
                 created_at=d.get("created_at", None),
@@ -4450,6 +4525,8 @@ class Device:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             can_configure_auto_lock=d.get("can_configure_auto_lock", None),
             can_hvac_cool=d.get("can_hvac_cool", None),
@@ -4488,40 +4565,26 @@ class Device:
             capabilities_supported=d.get("capabilities_supported", None),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            custom_metadata=DeepAttrDict(d.get("custom_metadata", None)),
+            custom_metadata=_record_from_dict(d.get("custom_metadata", None)),
             device_id=d.get("device_id", None),
-            device_manufacturer=(
-                cls.DeviceManufacturer.from_dict(d.get("device_manufacturer"))
-                if d.get("device_manufacturer") is not None
-                else None
+            device_manufacturer=_object_from_dict(
+                cls.DeviceManufacturer, d.get("device_manufacturer")
             ),
-            device_provider=(
-                cls.DeviceProvider.from_dict(d.get("device_provider"))
-                if d.get("device_provider") is not None
-                else None
+            device_provider=_object_from_dict(
+                cls.DeviceProvider, d.get("device_provider")
             ),
             device_type=d.get("device_type", None),
             display_name=d.get("display_name", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             is_managed=d.get("is_managed", None),
-            location=(
-                cls.Location.from_dict(d.get("location"))
-                if d.get("location") is not None
-                else None
-            ),
+            location=_object_from_dict(cls.Location, d.get("location")),
             nickname=d.get("nickname", None),
-            properties=(
-                cls.Properties.from_dict(d.get("properties"))
-                if d.get("properties") is not None
-                else None
-            ),
+            properties=_object_from_dict(cls.Properties, d.get("properties")),
             space_ids=d.get("space_ids", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/device_provider.py
+++ b/seam/resources/device_provider.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -160,6 +167,8 @@ class DeviceProvider:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             can_configure_auto_lock=d.get("can_configure_auto_lock", None),
             can_hvac_cool=d.get("can_hvac_cool", None),

--- a/seam/resources/instant_key.py
+++ b/seam/resources/instant_key.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -44,6 +51,8 @@ class InstantKey:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 logo_url=d.get("logo_url", None),
                 primary_color=d.get("primary_color", None),
@@ -62,14 +71,12 @@ class InstantKey:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             client_session_id=d.get("client_session_id", None),
             created_at=d.get("created_at", None),
-            customization=(
-                cls.Customization.from_dict(d.get("customization"))
-                if d.get("customization") is not None
-                else None
-            ),
+            customization=_object_from_dict(cls.Customization, d.get("customization")),
             customization_profile_id=d.get("customization_profile_id", None),
             expires_at=d.get("expires_at", None),
             instant_key_id=d.get("instant_key_id", None),

--- a/seam/resources/noise_threshold.py
+++ b/seam/resources/noise_threshold.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -33,6 +40,8 @@ class NoiseThreshold:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             device_id=d.get("device_id", None),
             ends_daily_at=d.get("ends_daily_at", None),

--- a/seam/resources/pagination.py
+++ b/seam/resources/pagination.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -20,6 +27,8 @@ class Pagination:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             has_next_page=d.get("has_next_page", None),
             next_page_cursor=d.get("next_page_cursor", None),

--- a/seam/resources/phone.py
+++ b/seam/resources/phone.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -44,6 +51,8 @@ class Phone:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -81,6 +90,8 @@ class Phone:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         endpoint_id=d.get("endpoint_id", None),
                         is_active=d.get("is_active", None),
@@ -91,10 +102,10 @@ class Phone:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    endpoints=[
-                        cls.Endpoints.from_dict(i) for i in d.get("endpoints") or []
-                    ],
+                    endpoints=_object_list_from_dict(cls.Endpoints, d.get("endpoints")),
                     has_active_endpoint=d.get("has_active_endpoint", None),
                 )
 
@@ -109,6 +120,8 @@ class Phone:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     has_active_phone=d.get("has_active_phone", None),
                 )
@@ -122,20 +135,16 @@ class Phone:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                assa_abloy_credential_service_metadata=(
-                    cls.AssaAbloyCredentialServiceMetadata.from_dict(
-                        d.get("assa_abloy_credential_service_metadata")
-                    )
-                    if d.get("assa_abloy_credential_service_metadata") is not None
-                    else None
+                assa_abloy_credential_service_metadata=_object_from_dict(
+                    cls.AssaAbloyCredentialServiceMetadata,
+                    d.get("assa_abloy_credential_service_metadata"),
                 ),
-                salto_space_credential_service_metadata=(
-                    cls.SaltoSpaceCredentialServiceMetadata.from_dict(
-                        d.get("salto_space_credential_service_metadata")
-                    )
-                    if d.get("salto_space_credential_service_metadata") is not None
-                    else None
+                salto_space_credential_service_metadata=_object_from_dict(
+                    cls.SaltoSpaceCredentialServiceMetadata,
+                    d.get("salto_space_credential_service_metadata"),
                 ),
             )
 
@@ -155,6 +164,8 @@ class Phone:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -174,19 +185,17 @@ class Phone:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             created_at=d.get("created_at", None),
-            custom_metadata=DeepAttrDict(d.get("custom_metadata", None)),
+            custom_metadata=_record_from_dict(d.get("custom_metadata", None)),
             device_id=d.get("device_id", None),
             device_type=d.get("device_type", None),
             display_name=d.get("display_name", None),
-            errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+            errors=_object_list_from_dict(cls.Errors, d.get("errors")),
             nickname=d.get("nickname", None),
-            properties=(
-                cls.Properties.from_dict(d.get("properties"))
-                if d.get("properties") is not None
-                else None
-            ),
-            warnings=[cls.Warnings.from_dict(i) for i in d.get("warnings") or []],
+            properties=_object_from_dict(cls.Properties, d.get("properties")),
+            warnings=_object_list_from_dict(cls.Warnings, d.get("warnings")),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/seam_event.py
+++ b/seam/resources/seam_event.py
@@ -8587,5 +8587,4 @@ def seam_event_from_dict(d: Any) -> SeamEvent:
     try:
         return variant.from_dict(d)
     except Exception:  # pylint: disable=broad-exception-caught
-        # A known discriminator whose payload does not convert is still readable.
         return cast(SeamEvent, DeepAttrDict(d))

--- a/seam/resources/seam_event.py
+++ b/seam/resources/seam_event.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -44,14 +51,18 @@ class AccessCodeCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -107,6 +118,8 @@ class AccessCodeChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 from_=d.get("from", None),
                 property=d.get("property", None),
@@ -129,19 +142,22 @@ class AccessCodeChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             change_reason=d.get("change_reason", None),
-            changed_properties=[
-                cls.ChangedProperties.from_dict(i)
-                for i in d.get("changed_properties") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            changed_properties=_object_list_from_dict(
+                cls.ChangedProperties, d.get("changed_properties")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -193,6 +209,8 @@ class AccessCodeNameChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 name=d.get("name", None),
             )
@@ -207,6 +225,8 @@ class AccessCodeNameChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 name=d.get("name", None),
             )
@@ -228,24 +248,26 @@ class AccessCodeNameChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             description=d.get("description", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
-            from_=(
-                cls.From.from_dict(d.get("from")) if d.get("from") is not None else None
-            ),
+            from_=_object_from_dict(cls.From, d.get("from")),
             occurred_at=d.get("occurred_at", None),
-            to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+            to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
         )
 
@@ -292,6 +314,8 @@ class AccessCodeCodeChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 code=d.get("code", None),
             )
@@ -306,6 +330,8 @@ class AccessCodeCodeChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 code=d.get("code", None),
             )
@@ -327,24 +353,26 @@ class AccessCodeCodeChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             description=d.get("description", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
-            from_=(
-                cls.From.from_dict(d.get("from")) if d.get("from") is not None else None
-            ),
+            from_=_object_from_dict(cls.From, d.get("from")),
             occurred_at=d.get("occurred_at", None),
-            to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+            to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
         )
 
@@ -394,6 +422,8 @@ class AccessCodeTimeFrameChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 ends_at=d.get("ends_at", None),
                 starts_at=d.get("starts_at", None),
@@ -412,6 +442,8 @@ class AccessCodeTimeFrameChangedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 ends_at=d.get("ends_at", None),
                 starts_at=d.get("starts_at", None),
@@ -434,24 +466,26 @@ class AccessCodeTimeFrameChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             description=d.get("description", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
-            from_=(
-                cls.From.from_dict(d.get("from")) if d.get("from") is not None else None
-            ),
+            from_=_object_from_dict(cls.From, d.get("from")),
             occurred_at=d.get("occurred_at", None),
-            to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+            to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
         )
 
@@ -508,10 +542,12 @@ class AccessCodeMutationsRequestedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                from_=DeepAttrDict(d.get("from", None)),
+                from_=_record_from_dict(d.get("from", None)),
                 mutation_code=d.get("mutation_code", None),
-                to=DeepAttrDict(d.get("to", None)),
+                to=_record_from_dict(d.get("to", None)),
             )
 
     access_code_id: str
@@ -529,23 +565,26 @@ class AccessCodeMutationsRequestedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
-            requested_mutations=[
-                cls.RequestedMutations.from_dict(i)
-                for i in d.get("requested_mutations") or []
-            ],
+            requested_mutations=_object_list_from_dict(
+                cls.RequestedMutations, d.get("requested_mutations")
+            ),
             workspace_id=d.get("workspace_id", None),
         )
 
@@ -593,15 +632,19 @@ class AccessCodeScheduledOnDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             code=d.get("code", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -654,15 +697,19 @@ class AccessCodeSetOnDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             code=d.get("code", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -712,14 +759,18 @@ class AccessCodeRemovedFromDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -784,6 +835,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -807,6 +860,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -830,6 +885,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -853,6 +910,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -876,6 +935,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -899,6 +960,8 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -925,37 +988,37 @@ class AccessCodeDelayInSettingOnDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_code_errors=[
-                cls.AccessCodeErrors.from_dict(i)
-                for i in d.get("access_code_errors") or []
-            ],
+            access_code_errors=_object_list_from_dict(
+                cls.AccessCodeErrors, d.get("access_code_errors")
+            ),
             access_code_id=d.get("access_code_id", None),
-            access_code_warnings=[
-                cls.AccessCodeWarnings.from_dict(i)
-                for i in d.get("access_code_warnings") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            access_code_warnings=_object_list_from_dict(
+                cls.AccessCodeWarnings, d.get("access_code_warnings")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -1019,6 +1082,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1042,6 +1107,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1065,6 +1132,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1088,6 +1157,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1111,6 +1182,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1134,6 +1207,8 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1160,37 +1235,37 @@ class AccessCodeFailedToSetOnDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_code_errors=[
-                cls.AccessCodeErrors.from_dict(i)
-                for i in d.get("access_code_errors") or []
-            ],
+            access_code_errors=_object_list_from_dict(
+                cls.AccessCodeErrors, d.get("access_code_errors")
+            ),
             access_code_id=d.get("access_code_id", None),
-            access_code_warnings=[
-                cls.AccessCodeWarnings.from_dict(i)
-                for i in d.get("access_code_warnings") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            access_code_warnings=_object_list_from_dict(
+                cls.AccessCodeWarnings, d.get("access_code_warnings")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -1242,15 +1317,19 @@ class AccessCodeDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             code=d.get("code", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -1319,6 +1398,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1342,6 +1423,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1365,6 +1448,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1388,6 +1473,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1411,6 +1498,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1434,6 +1523,8 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1460,37 +1551,37 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_code_errors=[
-                cls.AccessCodeErrors.from_dict(i)
-                for i in d.get("access_code_errors") or []
-            ],
+            access_code_errors=_object_list_from_dict(
+                cls.AccessCodeErrors, d.get("access_code_errors")
+            ),
             access_code_id=d.get("access_code_id", None),
-            access_code_warnings=[
-                cls.AccessCodeWarnings.from_dict(i)
-                for i in d.get("access_code_warnings") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            access_code_warnings=_object_list_from_dict(
+                cls.AccessCodeWarnings, d.get("access_code_warnings")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -1554,6 +1645,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1577,6 +1670,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1600,6 +1695,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1623,6 +1720,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1646,6 +1745,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -1669,6 +1770,8 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1695,37 +1798,37 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_code_errors=[
-                cls.AccessCodeErrors.from_dict(i)
-                for i in d.get("access_code_errors") or []
-            ],
+            access_code_errors=_object_list_from_dict(
+                cls.AccessCodeErrors, d.get("access_code_errors")
+            ),
             access_code_id=d.get("access_code_id", None),
-            access_code_warnings=[
-                cls.AccessCodeWarnings.from_dict(i)
-                for i in d.get("access_code_warnings") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            access_code_warnings=_object_list_from_dict(
+                cls.AccessCodeWarnings, d.get("access_code_warnings")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -1774,14 +1877,18 @@ class AccessCodeModifiedExternalToSeamEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -1831,14 +1938,18 @@ class AccessCodeDeletedExternalToSeamEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -1891,15 +2002,19 @@ class AccessCodeBackupAccessCodePulledEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             backup_access_code_id=d.get("backup_access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -1949,14 +2064,18 @@ class AccessCodeUnmanagedConvertedToManagedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -2021,6 +2140,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -2044,6 +2165,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -2067,6 +2190,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -2090,6 +2215,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -2113,6 +2240,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -2136,6 +2265,8 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -2162,37 +2293,37 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            access_code_errors=[
-                cls.AccessCodeErrors.from_dict(i)
-                for i in d.get("access_code_errors") or []
-            ],
+            access_code_errors=_object_list_from_dict(
+                cls.AccessCodeErrors, d.get("access_code_errors")
+            ),
             access_code_id=d.get("access_code_id", None),
-            access_code_warnings=[
-                cls.AccessCodeWarnings.from_dict(i)
-                for i in d.get("access_code_warnings") or []
-            ],
-            connected_account_custom_metadata=DeepAttrDict(
+            access_code_warnings=_object_list_from_dict(
+                cls.AccessCodeWarnings, d.get("access_code_warnings")
+            ),
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -2241,14 +2372,18 @@ class AccessCodeUnmanagedCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -2298,14 +2433,18 @@ class AccessCodeUnmanagedRemovedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -2343,6 +2482,8 @@ class AccessGrantCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             created_at=d.get("created_at", None),
@@ -2382,6 +2523,8 @@ class AccessGrantDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             created_at=d.get("created_at", None),
@@ -2421,6 +2564,8 @@ class AccessGrantAccessGrantedToAllDoorsEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             created_at=d.get("created_at", None),
@@ -2463,6 +2608,8 @@ class AccessGrantAccessGrantedToDoorEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             acs_entrance_id=d.get("acs_entrance_id", None),
@@ -2506,6 +2653,8 @@ class AccessGrantAccessToDoorLostEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             acs_entrance_id=d.get("acs_entrance_id", None),
@@ -2555,6 +2704,8 @@ class AccessGrantAccessTimesChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             access_grant_key=d.get("access_grant_key", None),
@@ -2603,6 +2754,8 @@ class AccessGrantCouldNotCreateRequestedAccessMethodsEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             created_at=d.get("created_at", None),
@@ -2656,6 +2809,8 @@ class AccessMethodIssuedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2705,6 +2860,8 @@ class AccessMethodRevokedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2752,6 +2909,8 @@ class AccessMethodCardEncodingRequiredEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2799,6 +2958,8 @@ class AccessMethodDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2852,6 +3013,8 @@ class AccessMethodReissuedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2901,6 +3064,8 @@ class AccessMethodCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2948,6 +3113,8 @@ class AccessMethodDelayInIssuingEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -2995,6 +3162,8 @@ class AccessMethodFailedToIssueEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_ids=d.get("access_grant_ids", None),
             access_grant_keys=d.get("access_grant_keys", None),
@@ -3039,6 +3208,8 @@ class AcsSystemConnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_system_id=d.get("acs_system_id", None),
             connected_account_id=d.get("connected_account_id", None),
@@ -3082,6 +3253,8 @@ class AcsSystemAddedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_system_id=d.get("acs_system_id", None),
             connected_account_id=d.get("connected_account_id", None),
@@ -3139,6 +3312,8 @@ class AcsSystemDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -3162,6 +3337,8 @@ class AcsSystemDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3185,6 +3362,8 @@ class AcsSystemDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -3208,6 +3387,8 @@ class AcsSystemDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -3229,25 +3410,23 @@ class AcsSystemDisconnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            acs_system_errors=[
-                cls.AcsSystemErrors.from_dict(i)
-                for i in d.get("acs_system_errors") or []
-            ],
+            acs_system_errors=_object_list_from_dict(
+                cls.AcsSystemErrors, d.get("acs_system_errors")
+            ),
             acs_system_id=d.get("acs_system_id", None),
-            acs_system_warnings=[
-                cls.AcsSystemWarnings.from_dict(i)
-                for i in d.get("acs_system_warnings") or []
-            ],
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            acs_system_warnings=_object_list_from_dict(
+                cls.AcsSystemWarnings, d.get("acs_system_warnings")
+            ),
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -3291,6 +3470,8 @@ class AcsCredentialDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_credential_id=d.get("acs_credential_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3338,6 +3519,8 @@ class AcsCredentialIssuedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_credential_id=d.get("acs_credential_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3385,6 +3568,8 @@ class AcsCredentialReissuedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_credential_id=d.get("acs_credential_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3432,6 +3617,8 @@ class AcsCredentialInvalidatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_credential_id=d.get("acs_credential_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3479,6 +3666,8 @@ class AcsUserCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_system_id=d.get("acs_system_id", None),
             acs_user_id=d.get("acs_user_id", None),
@@ -3526,6 +3715,8 @@ class AcsUserDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_system_id=d.get("acs_system_id", None),
             acs_user_id=d.get("acs_user_id", None),
@@ -3573,6 +3764,8 @@ class AcsEncoderAddedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_encoder_id=d.get("acs_encoder_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3620,6 +3813,8 @@ class AcsEncoderRemovedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_encoder_id=d.get("acs_encoder_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3667,6 +3862,8 @@ class AcsAccessGroupDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_access_group_id=d.get("acs_access_group_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3714,6 +3911,8 @@ class AcsEntranceAddedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_id=d.get("acs_entrance_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3761,6 +3960,8 @@ class AcsEntranceRemovedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_id=d.get("acs_entrance_id", None),
             acs_system_id=d.get("acs_system_id", None),
@@ -3802,6 +4003,8 @@ class ClientSessionDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             client_session_id=d.get("client_session_id", None),
             created_at=d.get("created_at", None),
@@ -3850,9 +4053,11 @@ class ConnectedAccountConnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             connect_webview_id=d.get("connect_webview_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -3900,9 +4105,11 @@ class ConnectedAccountCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             connect_webview_id=d.get("connect_webview_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -3952,9 +4159,11 @@ class ConnectedAccountSuccessfulLoginEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             connect_webview_id=d.get("connect_webview_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -4008,6 +4217,8 @@ class ConnectedAccountDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -4031,6 +4242,8 @@ class ConnectedAccountDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4050,19 +4263,19 @@ class ConnectedAccountDisconnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -4103,8 +4316,10 @@ class ConnectedAccountCompletedFirstSyncEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -4151,8 +4366,10 @@ class ConnectedAccountDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -4197,8 +4414,10 @@ class ConnectedAccountCompletedFirstSyncAfterReconnectionEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -4252,6 +4471,8 @@ class ConnectedAccountReauthorizationRequestedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -4275,6 +4496,8 @@ class ConnectedAccountReauthorizationRequestedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -4294,19 +4517,19 @@ class ConnectedAccountReauthorizationRequestedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -4356,6 +4579,8 @@ class ActionAttemptLockDoorSucceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4411,6 +4636,8 @@ class ActionAttemptLockDoorFailedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4466,6 +4693,8 @@ class ActionAttemptUnlockDoorSucceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4521,6 +4750,8 @@ class ActionAttemptUnlockDoorFailedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4576,6 +4807,8 @@ class ActionAttemptSimulateKeypadCodeEntrySucceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4631,6 +4864,8 @@ class ActionAttemptSimulateKeypadCodeEntryFailedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4686,6 +4921,8 @@ class ActionAttemptSimulateManualLockViaKeypadSucceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4741,6 +4978,8 @@ class ActionAttemptSimulateManualLockViaKeypadFailedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             action_attempt_id=d.get("action_attempt_id", None),
             action_type=d.get("action_type", None),
@@ -4793,9 +5032,11 @@ class ConnectWebviewLoginSucceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             connect_webview_id=d.get("connect_webview_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -4837,6 +5078,8 @@ class ConnectWebviewLoginFailedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             connect_webview_id=d.get("connect_webview_id", None),
             created_at=d.get("created_at", None),
@@ -4888,14 +5131,18 @@ class DeviceConnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -4945,14 +5192,18 @@ class DeviceAddedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5002,14 +5253,18 @@ class DeviceConvertedToUnmanagedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5059,14 +5314,18 @@ class DeviceUnmanagedConvertedToManagedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5116,14 +5375,18 @@ class DeviceUnmanagedConnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5186,6 +5449,8 @@ class DeviceDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -5209,6 +5474,8 @@ class DeviceDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -5232,6 +5499,8 @@ class DeviceDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -5255,6 +5524,8 @@ class DeviceDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -5282,29 +5553,31 @@ class DeviceDisconnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             error_code=d.get("error_code", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5367,6 +5640,8 @@ class DeviceUnmanagedDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -5390,6 +5665,8 @@ class DeviceUnmanagedDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -5413,6 +5690,8 @@ class DeviceUnmanagedDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -5436,6 +5715,8 @@ class DeviceUnmanagedDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -5463,29 +5744,31 @@ class DeviceUnmanagedDisconnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             error_code=d.get("error_code", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5535,14 +5818,18 @@ class DeviceTamperedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5601,19 +5888,23 @@ class DeviceLowBatteryEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             accessory_keypad_battery_level=d.get(
                 "accessory_keypad_battery_level", None
             ),
             battery_level=d.get("battery_level", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
             device_battery_level=d.get("device_battery_level", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5669,16 +5960,20 @@ class DeviceBatteryStatusChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             battery_level=d.get("battery_level", None),
             battery_status=d.get("battery_status", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5728,14 +6023,18 @@ class DeviceRemovedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5788,14 +6087,18 @@ class DeviceDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             device_name=d.get("device_name", None),
             event_description=d.get("event_description", None),
@@ -5846,14 +6149,18 @@ class DeviceThirdPartyIntegrationDetectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5903,14 +6210,18 @@ class DeviceThirdPartyIntegrationNoLongerDetectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -5960,14 +6271,18 @@ class DeviceSaltoPrivacyModeActivatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6017,14 +6332,18 @@ class DeviceSaltoPrivacyModeDeactivatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6085,6 +6404,8 @@ class DeviceConnectionBecameFlakyEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6108,6 +6429,8 @@ class DeviceConnectionBecameFlakyEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6131,6 +6454,8 @@ class DeviceConnectionBecameFlakyEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6154,6 +6479,8 @@ class DeviceConnectionBecameFlakyEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6178,29 +6505,31 @@ class DeviceConnectionBecameFlakyEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -6249,14 +6578,18 @@ class DeviceConnectionStabilizedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6317,6 +6650,8 @@ class DeviceErrorSubscriptionRequiredEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6340,6 +6675,8 @@ class DeviceErrorSubscriptionRequiredEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6363,6 +6700,8 @@ class DeviceErrorSubscriptionRequiredEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6386,6 +6725,8 @@ class DeviceErrorSubscriptionRequiredEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6410,29 +6751,31 @@ class DeviceErrorSubscriptionRequiredEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -6481,14 +6824,18 @@ class DeviceErrorSubscriptionRequiredResolvedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6538,14 +6885,18 @@ class DeviceAccessoryKeypadConnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6606,6 +6957,8 @@ class DeviceAccessoryKeypadDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6629,6 +6982,8 @@ class DeviceAccessoryKeypadDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6652,6 +7007,8 @@ class DeviceAccessoryKeypadDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -6675,6 +7032,8 @@ class DeviceAccessoryKeypadDisconnectedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -6699,29 +7058,31 @@ class DeviceAccessoryKeypadDisconnectedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
-            connected_account_errors=[
-                cls.ConnectedAccountErrors.from_dict(i)
-                for i in d.get("connected_account_errors") or []
-            ],
+            connected_account_errors=_object_list_from_dict(
+                cls.ConnectedAccountErrors, d.get("connected_account_errors")
+            ),
             connected_account_id=d.get("connected_account_id", None),
-            connected_account_warnings=[
-                cls.ConnectedAccountWarnings.from_dict(i)
-                for i in d.get("connected_account_warnings") or []
-            ],
+            connected_account_warnings=_object_list_from_dict(
+                cls.ConnectedAccountWarnings, d.get("connected_account_warnings")
+            ),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
-            device_errors=[
-                cls.DeviceErrors.from_dict(i) for i in d.get("device_errors") or []
-            ],
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
+            device_errors=_object_list_from_dict(
+                cls.DeviceErrors, d.get("device_errors")
+            ),
             device_id=d.get("device_id", None),
-            device_warnings=[
-                cls.DeviceWarnings.from_dict(i) for i in d.get("device_warnings") or []
-            ],
+            device_warnings=_object_list_from_dict(
+                cls.DeviceWarnings, d.get("device_warnings")
+            ),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
@@ -6788,24 +7149,28 @@ class NoiseSensorNoiseThresholdTriggeredEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
-            minut_metadata=DeepAttrDict(d.get("minut_metadata", None)),
+            minut_metadata=_record_from_dict(d.get("minut_metadata", None)),
             noise_level_decibels=d.get("noise_level_decibels", None),
             noise_level_nrs=d.get("noise_level_nrs", None),
             noise_threshold_id=d.get("noise_threshold_id", None),
             noise_threshold_name=d.get("noise_threshold_name", None),
-            noiseaware_metadata=DeepAttrDict(d.get("noiseaware_metadata", None)),
+            noiseaware_metadata=_record_from_dict(d.get("noiseaware_metadata", None)),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
         )
@@ -6872,18 +7237,22 @@ class LockLockedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             access_code_is_managed=d.get("access_code_is_managed", None),
             action_attempt_id=d.get("action_attempt_id", None),
             code=d.get("code", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -6957,18 +7326,22 @@ class LockUnlockedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             access_code_is_managed=d.get("access_code_is_managed", None),
             action_attempt_id=d.get("action_attempt_id", None),
             code=d.get("code", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7032,6 +7405,8 @@ class LockAccessDeniedEvent:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 message=d.get("message", None),
                 reason_code=d.get("reason_code", None),
@@ -7053,25 +7428,25 @@ class LockAccessDeniedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
-            reason=(
-                cls.Reason.from_dict(d.get("reason"))
-                if d.get("reason") is not None
-                else None
-            ),
+            reason=_object_from_dict(cls.Reason, d.get("reason")),
             workspace_id=d.get("workspace_id", None),
         )
 
@@ -7125,15 +7500,19 @@ class ThermostatClimatePresetActivatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             climate_preset_key=d.get("climate_preset_key", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7206,8 +7585,10 @@ class ThermostatManuallyAdjustedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -7215,7 +7596,9 @@ class ThermostatManuallyAdjustedEvent:
             cooling_set_point_fahrenheit=d.get("cooling_set_point_fahrenheit", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7288,14 +7671,18 @@ class ThermostatTemperatureThresholdExceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7369,14 +7756,18 @@ class ThermostatTemperatureThresholdNoLongerExceededEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7444,8 +7835,10 @@ class ThermostatTemperatureReachedSetPointEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
@@ -7455,7 +7848,9 @@ class ThermostatTemperatureReachedSetPointEvent:
             desired_temperature_fahrenheit=d.get(
                 "desired_temperature_fahrenheit", None
             ),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7513,14 +7908,18 @@ class ThermostatTemperatureChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7575,14 +7974,18 @@ class DeviceNameChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             device_name=d.get("device_name", None),
             event_description=d.get("event_description", None),
@@ -7645,15 +8048,19 @@ class CameraActivatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             activation_reason=d.get("activation_reason", None),
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7712,14 +8119,18 @@ class DeviceDoorbellRangEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
-            connected_account_custom_metadata=DeepAttrDict(
+            connected_account_custom_metadata=_record_from_dict(
                 d.get("connected_account_custom_metadata", None)
             ),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
             customer_key=d.get("customer_key", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7762,9 +8173,13 @@ class PhoneDeactivatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             created_at=d.get("created_at", None),
-            device_custom_metadata=DeepAttrDict(d.get("device_custom_metadata", None)),
+            device_custom_metadata=_record_from_dict(
+                d.get("device_custom_metadata", None)
+            ),
             device_id=d.get("device_id", None),
             event_description=d.get("event_description", None),
             event_id=d.get("event_id", None),
@@ -7811,6 +8226,8 @@ class SpaceDeviceMembershipChangedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_ids=d.get("acs_entrance_ids", None),
             created_at=d.get("created_at", None),
@@ -7862,6 +8279,8 @@ class SpaceCreatedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_ids=d.get("acs_entrance_ids", None),
             created_at=d.get("created_at", None),
@@ -7913,6 +8332,8 @@ class SpaceDeletedEvent:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_ids=d.get("acs_entrance_ids", None),
             created_at=d.get("created_at", None),
@@ -8153,10 +8574,18 @@ _SEAM_EVENT_VARIANTS: Dict[str, Any] = {
 def seam_event_from_dict(d: Any) -> SeamEvent:
     """Deserialize a known event_type variant.
 
-    Unknown discriminator values return ``DeepAttrDict`` so payloads from a
-    newer API remain readable. The static return type covers known variants.
+    An unrecognized discriminator, or a known one whose payload does not
+    convert, returns ``DeepAttrDict`` so payloads from a newer API remain
+    readable. The static return type covers known variants.
     """
-    variant = _SEAM_EVENT_VARIANTS.get(d.get("event_type"))
+    if not isinstance(d, dict):
+        return cast(SeamEvent, DeepAttrDict(d) if isinstance(d, dict) else d)
+    key = d.get("event_type")
+    variant = _SEAM_EVENT_VARIANTS.get(key) if isinstance(key, str) else None
     if variant is None:
         return cast(SeamEvent, DeepAttrDict(d))
-    return variant.from_dict(d)
+    try:
+        return variant.from_dict(d)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # A known discriminator whose payload does not convert is still readable.
+        return cast(SeamEvent, DeepAttrDict(d))

--- a/seam/resources/space.py
+++ b/seam/resources/space.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -49,6 +56,8 @@ class Space:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 address=d.get("address", None),
                 default_checkin_time=d.get("default_checkin_time", None),
@@ -69,6 +78,8 @@ class Space:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 latitude=d.get("latitude", None),
                 longitude=d.get("longitude", None),
@@ -88,22 +99,16 @@ class Space:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_entrance_count=d.get("acs_entrance_count", None),
             created_at=d.get("created_at", None),
-            customer_data=(
-                cls.CustomerData.from_dict(d.get("customer_data"))
-                if d.get("customer_data") is not None
-                else None
-            ),
+            customer_data=_object_from_dict(cls.CustomerData, d.get("customer_data")),
             customer_key=d.get("customer_key", None),
             device_count=d.get("device_count", None),
             display_name=d.get("display_name", None),
-            geolocation=(
-                cls.Geolocation.from_dict(d.get("geolocation"))
-                if d.get("geolocation") is not None
-                else None
-            ),
+            geolocation=_object_from_dict(cls.Geolocation, d.get("geolocation")),
             name=d.get("name", None),
             space_id=d.get("space_id", None),
             space_key=d.get("space_key", None),

--- a/seam/resources/thermostat_daily_program.py
+++ b/seam/resources/thermostat_daily_program.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -35,6 +42,8 @@ class ThermostatDailyProgram:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 climate_preset_key=d.get("climate_preset_key", None),
                 starts_at_time=d.get("starts_at_time", None),
@@ -49,11 +58,13 @@ class ThermostatDailyProgram:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             created_at=d.get("created_at", None),
             device_id=d.get("device_id", None),
             name=d.get("name", None),
-            periods=[cls.Periods.from_dict(i) for i in d.get("periods") or []],
+            periods=_object_list_from_dict(cls.Periods, d.get("periods")),
             thermostat_daily_program_id=d.get("thermostat_daily_program_id", None),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/thermostat_schedule.py
+++ b/seam/resources/thermostat_schedule.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -47,6 +54,8 @@ class ThermostatSchedule:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -67,12 +76,14 @@ class ThermostatSchedule:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             climate_preset_key=d.get("climate_preset_key", None),
             created_at=d.get("created_at", None),
             device_id=d.get("device_id", None),
             ends_at=d.get("ends_at", None),
-            errors=[cls.Errors.from_dict(i) for i in d.get("errors") or []],
+            errors=_object_list_from_dict(cls.Errors, d.get("errors")),
             is_override_allowed=d.get("is_override_allowed", None),
             max_override_period_minutes=d.get("max_override_period_minutes", None),
             name=d.get("name", None),

--- a/seam/resources/unmanaged_access_code.py
+++ b/seam/resources/unmanaged_access_code.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -90,6 +90,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 is_cancellable=d.get("is_cancellable", None),
                 is_early_checkin_able=d.get("is_early_checkin_able", None),
@@ -121,6 +123,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -148,6 +152,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -175,6 +181,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -208,6 +216,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -237,6 +247,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -277,6 +289,8 @@ class UnmanagedAccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     field=d.get("field", None),
                     from_=d.get("from", None),
@@ -292,16 +306,17 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 change_type=d.get("change_type", None),
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
                 is_access_code_error=d.get("is_access_code_error", None),
                 message=d.get("message", None),
-                modified_fields=[
-                    cls.ModifiedFields.from_dict(i)
-                    for i in d.get("modified_fields") or []
-                ],
+                modified_fields=_object_list_from_dict(
+                    cls.ModifiedFields, d.get("modified_fields")
+                ),
             )
 
     @dataclass
@@ -324,6 +339,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -351,6 +368,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -378,6 +397,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -405,6 +426,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -432,6 +455,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -462,6 +487,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -493,6 +520,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -524,6 +553,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -555,6 +586,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -583,6 +616,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -610,6 +645,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -637,6 +674,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -664,6 +703,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -691,6 +732,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -718,6 +761,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -745,6 +790,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -772,6 +819,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -799,6 +848,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -829,6 +880,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -854,6 +907,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -877,6 +932,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -914,6 +971,8 @@ class UnmanagedAccessCode:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     field=d.get("field", None),
                     from_=d.get("from", None),
@@ -928,14 +987,15 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 change_type=d.get("change_type", None),
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
-                modified_fields=[
-                    cls.ModifiedFields.from_dict(i)
-                    for i in d.get("modified_fields") or []
-                ],
+                modified_fields=_object_list_from_dict(
+                    cls.ModifiedFields, d.get("modified_fields")
+                ),
                 warning_code=d.get("warning_code", None),
             )
 
@@ -956,6 +1016,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -979,6 +1041,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1002,6 +1066,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1025,6 +1091,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1048,6 +1116,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1071,6 +1141,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1094,6 +1166,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1117,6 +1191,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1140,6 +1216,8 @@ class UnmanagedAccessCode:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1249,6 +1327,8 @@ class UnmanagedAccessCode:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_code_id=d.get("access_code_id", None),
             cannot_be_managed=d.get("cannot_be_managed", None),
@@ -1258,26 +1338,20 @@ class UnmanagedAccessCode:
             code=d.get("code", None),
             created_at=d.get("created_at", None),
             device_id=d.get("device_id", None),
-            dormakaba_oracode_metadata=(
-                cls.DormakabaOracodeMetadata.from_dict(
-                    d.get("dormakaba_oracode_metadata")
-                )
-                if d.get("dormakaba_oracode_metadata") is not None
-                else None
+            dormakaba_oracode_metadata=_object_from_dict(
+                cls.DormakabaOracodeMetadata, d.get("dormakaba_oracode_metadata")
             ),
             ends_at=d.get("ends_at", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             is_managed=d.get("is_managed", None),
             name=d.get("name", None),
             starts_at=d.get("starts_at", None),
             status=d.get("status", None),
             type=d.get("type", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/unmanaged_access_grant.py
+++ b/seam/resources/unmanaged_access_grant.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -67,6 +67,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -98,6 +100,8 @@ class UnmanagedAccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -115,6 +119,8 @@ class UnmanagedAccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     common_code_key=d.get("common_code_key", None),
                     device_ids=d.get("device_ids", None),
@@ -128,16 +134,14 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -169,6 +173,8 @@ class UnmanagedAccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -187,6 +193,8 @@ class UnmanagedAccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -201,17 +209,15 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method_ids=d.get("access_method_ids", None),
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -240,6 +246,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 code=d.get("code", None),
                 created_access_method_ids=d.get("created_access_method_ids", None),
@@ -266,6 +274,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -289,6 +299,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -324,6 +336,8 @@ class UnmanagedAccessGrant:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_id=d.get("device_id", None),
                     error_code=d.get("error_code", None),
@@ -337,12 +351,13 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                failed_devices=[
-                    cls.FailedDevices.from_dict(i)
-                    for i in d.get("failed_devices") or []
-                ],
+                failed_devices=_object_list_from_dict(
+                    cls.FailedDevices, d.get("failed_devices")
+                ),
                 message=d.get("message", None),
                 warning_code=d.get("warning_code", None),
             )
@@ -367,6 +382,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 access_method_ids=d.get("access_method_ids", None),
                 created_at=d.get("created_at", None),
@@ -400,6 +417,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -429,6 +448,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -461,6 +482,8 @@ class UnmanagedAccessGrant:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 device_id=d.get("device_id", None),
@@ -520,35 +543,33 @@ class UnmanagedAccessGrant:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_grant_id=d.get("access_grant_id", None),
             access_method_ids=d.get("access_method_ids", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
             ends_at=d.get("ends_at", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             location_ids=d.get("location_ids", None),
             name=d.get("name", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            requested_access_methods=[
-                cls.RequestedAccessMethods.from_dict(i)
-                for i in d.get("requested_access_methods") or []
-            ],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
+            requested_access_methods=_object_list_from_dict(
+                cls.RequestedAccessMethods, d.get("requested_access_methods")
+            ),
             reservation_key=d.get("reservation_key", None),
             space_ids=d.get("space_ids", None),
             starts_at=d.get("starts_at", None),
             user_identity_id=d.get("user_identity_id", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/unmanaged_access_method.py
+++ b/seam/resources/unmanaged_access_method.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -64,6 +64,8 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -94,6 +96,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -108,6 +112,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -120,16 +126,14 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -156,6 +160,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -170,6 +176,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     device_ids=d.get("device_ids", None),
                 )
@@ -182,16 +190,14 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -221,6 +227,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -239,6 +247,8 @@ class UnmanagedAccessMethod:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     ends_at=d.get("ends_at", None),
                     starts_at=d.get("starts_at", None),
@@ -252,16 +262,14 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
-                from_=(
-                    cls.From.from_dict(d.get("from"))
-                    if d.get("from") is not None
-                    else None
-                ),
+                from_=_object_from_dict(cls.From, d.get("from")),
                 message=d.get("message", None),
                 mutation_code=d.get("mutation_code", None),
-                to=cls.To.from_dict(d.get("to")) if d.get("to") is not None else None,
+                to=_object_from_dict(cls.To, d.get("to")),
             )
 
     @dataclass
@@ -281,6 +289,8 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -304,6 +314,8 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -330,6 +342,8 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -354,6 +368,8 @@ class UnmanagedAccessMethod:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -408,16 +424,17 @@ class UnmanagedAccessMethod:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             access_method_id=d.get("access_method_id", None),
             code=d.get("code", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
             display_status=d.get("display_status", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             is_assignment_required=d.get("is_assignment_required", None),
             is_encoding_required=d.get("is_encoding_required", None),
             is_issued=d.get("is_issued", None),
@@ -425,15 +442,13 @@ class UnmanagedAccessMethod:
             is_ready_for_encoding=d.get("is_ready_for_encoding", None),
             issued_at=d.get("issued_at", None),
             mode=d.get("mode", None),
-            pending_mutations=[
-                _from_discriminated_dict(
-                    i, cls._PendingMutationsVariants, "mutation_code"
-                )
-                for i in d.get("pending_mutations") or []
-            ],
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            pending_mutations=_discriminated_list_from_dict(
+                d.get("pending_mutations"),
+                cls._PendingMutationsVariants,
+                "mutation_code",
+            ),
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/unmanaged_device.py
+++ b/seam/resources/unmanaged_device.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -105,6 +105,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -136,6 +138,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -167,6 +171,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -198,6 +204,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -226,6 +234,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -253,6 +263,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -280,6 +292,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -307,6 +321,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -334,6 +350,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -361,6 +379,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -388,6 +408,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -415,6 +437,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -442,6 +466,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -472,6 +498,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 error_code=d.get("error_code", None),
@@ -500,6 +528,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 location_name=d.get("location_name", None),
                 room_name=d.get("room_name", None),
@@ -553,6 +583,8 @@ class UnmanagedDevice:
 
                 @classmethod
                 def from_dict(cls, d: Any):
+                    if not isinstance(d, dict):
+                        d = {}
                     return cls(
                         level=d.get("level", None),
                     )
@@ -562,12 +594,10 @@ class UnmanagedDevice:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
-                    battery=(
-                        cls.Battery.from_dict(d.get("battery"))
-                        if d.get("battery") is not None
-                        else None
-                    ),
+                    battery=_object_from_dict(cls.Battery, d.get("battery")),
                     is_connected=d.get("is_connected", None),
                 )
 
@@ -585,6 +615,8 @@ class UnmanagedDevice:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     level=d.get("level", None),
                     status=d.get("status", None),
@@ -619,6 +651,8 @@ class UnmanagedDevice:
 
             @classmethod
             def from_dict(cls, d: Any):
+                if not isinstance(d, dict):
+                    d = {}
                 return cls(
                     accessory_keypad_supported=d.get(
                         "accessory_keypad_supported", None
@@ -651,26 +685,18 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
-                accessory_keypad=(
-                    cls.AccessoryKeypad.from_dict(d.get("accessory_keypad"))
-                    if d.get("accessory_keypad") is not None
-                    else None
+                accessory_keypad=_object_from_dict(
+                    cls.AccessoryKeypad, d.get("accessory_keypad")
                 ),
-                battery=(
-                    cls.Battery.from_dict(d.get("battery"))
-                    if d.get("battery") is not None
-                    else None
-                ),
+                battery=_object_from_dict(cls.Battery, d.get("battery")),
                 battery_level=d.get("battery_level", None),
                 image_alt_text=d.get("image_alt_text", None),
                 image_url=d.get("image_url", None),
                 manufacturer=d.get("manufacturer", None),
-                model=(
-                    cls.Model.from_dict(d.get("model"))
-                    if d.get("model") is not None
-                    else None
-                ),
+                model=_object_from_dict(cls.Model, d.get("model")),
                 name=d.get("name", None),
                 offline_access_codes_enabled=d.get(
                     "offline_access_codes_enabled", None
@@ -696,6 +722,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -719,6 +747,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -742,6 +772,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -765,6 +797,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -788,6 +822,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -811,6 +847,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -834,6 +872,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -857,6 +897,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -880,6 +922,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -903,6 +947,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -926,6 +972,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -949,6 +997,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -972,6 +1022,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -995,6 +1047,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1018,6 +1072,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1041,6 +1097,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1064,6 +1122,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1087,6 +1147,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1110,6 +1172,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1133,6 +1197,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1156,6 +1222,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1179,6 +1247,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1202,6 +1272,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1225,6 +1297,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1248,6 +1322,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1271,6 +1347,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1294,6 +1372,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -1323,6 +1403,8 @@ class UnmanagedDevice:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 active_access_code_count=d.get("active_access_code_count", None),
                 created_at=d.get("created_at", None),
@@ -1511,6 +1593,8 @@ class UnmanagedDevice:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             can_configure_auto_lock=d.get("can_configure_auto_lock", None),
             can_hvac_cool=d.get("can_hvac_cool", None),
@@ -1549,28 +1633,18 @@ class UnmanagedDevice:
             capabilities_supported=d.get("capabilities_supported", None),
             connected_account_id=d.get("connected_account_id", None),
             created_at=d.get("created_at", None),
-            custom_metadata=DeepAttrDict(d.get("custom_metadata", None)),
+            custom_metadata=_record_from_dict(d.get("custom_metadata", None)),
             device_id=d.get("device_id", None),
             device_type=d.get("device_type", None),
             display_name=d.get("display_name", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             is_managed=d.get("is_managed", None),
-            location=(
-                cls.Location.from_dict(d.get("location"))
-                if d.get("location") is not None
-                else None
+            location=_object_from_dict(cls.Location, d.get("location")),
+            properties=_object_from_dict(cls.Properties, d.get("properties")),
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
             ),
-            properties=(
-                cls.Properties.from_dict(d.get("properties"))
-                if d.get("properties") is not None
-                else None
-            ),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/unmanaged_user_identity.py
+++ b/seam/resources/unmanaged_user_identity.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -62,6 +62,8 @@ class UnmanagedUserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 acs_system_id=d.get("acs_system_id", None),
                 acs_user_id=d.get("acs_user_id", None),
@@ -87,6 +89,8 @@ class UnmanagedUserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -110,6 +114,8 @@ class UnmanagedUserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -142,23 +148,23 @@ class UnmanagedUserIdentity:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_user_ids=d.get("acs_user_ids", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
             email_address=d.get("email_address", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             full_name=d.get("full_name", None),
             merged_user_identity_ids=d.get("merged_user_identity_ids", None),
             merged_user_identity_keys=d.get("merged_user_identity_keys", None),
             phone_number=d.get("phone_number", None),
             user_identity_id=d.get("user_identity_id", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/user_identity.py
+++ b/seam/resources/user_identity.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
-
-
-def _from_discriminated_dict(
-    d: Any, variants: Dict[str, Any], discriminator: str
-) -> Any:
-    variant = variants.get(d.get(discriminator))
-    return DeepAttrDict(d) if variant is None else variant.from_dict(d)
 
 
 @dataclass
@@ -64,6 +64,8 @@ class UserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 acs_system_id=d.get("acs_system_id", None),
                 acs_user_id=d.get("acs_user_id", None),
@@ -89,6 +91,8 @@ class UserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -112,6 +116,8 @@ class UserIdentity:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 created_at=d.get("created_at", None),
                 message=d.get("message", None),
@@ -145,24 +151,24 @@ class UserIdentity:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             acs_user_ids=d.get("acs_user_ids", None),
             created_at=d.get("created_at", None),
             display_name=d.get("display_name", None),
             email_address=d.get("email_address", None),
-            errors=[
-                _from_discriminated_dict(i, cls._ErrorsVariants, "error_code")
-                for i in d.get("errors") or []
-            ],
+            errors=_discriminated_list_from_dict(
+                d.get("errors"), cls._ErrorsVariants, "error_code"
+            ),
             full_name=d.get("full_name", None),
             merged_user_identity_ids=d.get("merged_user_identity_ids", None),
             merged_user_identity_keys=d.get("merged_user_identity_keys", None),
             phone_number=d.get("phone_number", None),
             user_identity_id=d.get("user_identity_id", None),
             user_identity_key=d.get("user_identity_key", None),
-            warnings=[
-                _from_discriminated_dict(i, cls._WarningsVariants, "warning_code")
-                for i in d.get("warnings") or []
-            ],
+            warnings=_discriminated_list_from_dict(
+                d.get("warnings"), cls._WarningsVariants, "warning_code"
+            ),
             workspace_id=d.get("workspace_id", None),
         )

--- a/seam/resources/webhook.py
+++ b/seam/resources/webhook.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -23,6 +30,8 @@ class Webhook:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             event_types=d.get("event_types", None),
             secret=d.get("secret", None),

--- a/seam/resources/workspace.py
+++ b/seam/resources/workspace.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from dataclasses import dataclass
 from ..deep_attr_dict import DeepAttrDict
+from ..parse import (
+    discriminated_list_from_dict as _discriminated_list_from_dict,
+    object_from_dict as _object_from_dict,
+    object_list_from_dict as _object_list_from_dict,
+    record_from_dict as _record_from_dict,
+    required_object_from_dict as _required_object_from_dict,
+)
 from ..resource_mapping import ResourceMapping
 
 
@@ -51,6 +58,8 @@ class Workspace:
 
         @classmethod
         def from_dict(cls, d: Any):
+            if not isinstance(d, dict):
+                d = {}
             return cls(
                 inviter_logo_url=d.get("inviter_logo_url", None),
                 logo_shape=d.get("logo_shape", None),
@@ -72,15 +81,13 @@ class Workspace:
 
     @classmethod
     def from_dict(cls, d: Any):
+        if not isinstance(d, dict):
+            d = {}
         return cls(
             company_name=d.get("company_name", None),
             connect_partner_name=d.get("connect_partner_name", None),
-            connect_webview_customization=(
-                cls.ConnectWebviewCustomization.from_dict(
-                    d.get("connect_webview_customization")
-                )
-                if d.get("connect_webview_customization") is not None
-                else None
+            connect_webview_customization=_object_from_dict(
+                cls.ConnectWebviewCustomization, d.get("connect_webview_customization")
             ),
             is_publishable_key_auth_enabled=d.get(
                 "is_publishable_key_auth_enabled", None

--- a/test/total_parsing_test.py
+++ b/test/total_parsing_test.py
@@ -1,9 +1,4 @@
-"""Reading a response never fails on the shape of the payload.
-
-Seam adds event types, action types, and error codes between SDK releases, so a
-payload this version does not recognize has to stay readable rather than cost
-the caller the whole response. Each test here pins one shape that used to raise.
-"""
+"""Regression tests for reading responses that do not match the generated shape."""
 
 from seam.deep_attr_dict import DeepAttrDict
 from seam.exceptions import SeamActionAttemptUnknownStatusError
@@ -68,7 +63,6 @@ def test_an_unknown_event_type_stays_readable():
 
 
 def test_a_known_event_survives_one_malformed_field():
-    # Only the unusable field degrades; the event keeps its generated type.
     event = seam_event_from_dict(
         {
             "event_id": "e",
@@ -99,13 +93,6 @@ def test_a_discriminator_that_is_not_a_string_does_not_match_a_variant():
 
 
 def test_waiting_on_an_unknown_status_raises_rather_than_claiming_success():
-    """An unrecognized status supports neither conclusion the wait can return.
-
-    Reporting success would tell the caller the action completed when the SDK
-    cannot tell; polling on would block until the timeout and then report a
-    timeout that misdescribes what happened.
-    """
-
     attempt = action_attempt_from_dict(
         {"action_attempt_id": "aa", "action_type": "LOCK_DOOR", "status": "cancelled"}
     )

--- a/test/total_parsing_test.py
+++ b/test/total_parsing_test.py
@@ -1,0 +1,130 @@
+"""Reading a response never fails on the shape of the payload.
+
+Seam adds event types, action types, and error codes between SDK releases, so a
+payload this version does not recognize has to stay readable rather than cost
+the caller the whole response. Each test here pins one shape that used to raise.
+"""
+
+from seam.deep_attr_dict import DeepAttrDict
+from seam.exceptions import SeamActionAttemptUnknownStatusError
+from seam.modules.action_attempts import poll_until_ready
+from seam.resources.device import Device
+from seam.resources.action_attempt import action_attempt_from_dict
+from seam.resources.seam_event import (
+    AccessCodeCreatedEvent,
+    seam_event_from_dict,
+)
+
+
+def test_a_list_property_sent_as_a_scalar_reads_as_empty():
+    device = Device.from_dict({"device_id": "d", "errors": "oops"})
+
+    assert isinstance(device.errors, list)
+    assert not device.errors
+
+
+def test_a_list_item_that_is_not_an_object_is_kept_verbatim():
+    device = Device.from_dict({"device_id": "d", "errors": ["nope"]})
+
+    assert device.errors == ["nope"]
+
+
+def test_an_unknown_error_code_keeps_the_rest_of_the_resource():
+    device = Device.from_dict(
+        {
+            "device_id": "d",
+            "errors": [{"error_code": "brand_new", "message": "m"}],
+        }
+    )
+
+    assert device.device_id == "d"
+    assert isinstance(device.errors[0], DeepAttrDict)
+    assert device.errors[0].error_code == "brand_new"
+
+
+def test_a_nested_object_sent_as_a_scalar_reads_as_none():
+    device = Device.from_dict({"device_id": "d", "location": "nope"})
+
+    assert device.location is None
+
+
+def test_a_payload_that_is_not_an_object_still_yields_a_resource():
+    device = Device.from_dict("not an object")
+
+    assert device.device_id is None
+
+
+def test_an_unknown_event_type_stays_readable():
+    event = seam_event_from_dict(
+        {
+            "event_id": "e",
+            "event_type": "future.thing",
+            "future_field": {"nested": True},
+        }
+    )
+
+    assert isinstance(event, DeepAttrDict)
+    assert event.future_field.nested is True
+
+
+def test_a_known_event_survives_one_malformed_field():
+    # Only the unusable field degrades; the event keeps its generated type.
+    event = seam_event_from_dict(
+        {
+            "event_id": "e",
+            "event_type": "access_code.created",
+            "access_code_id": "a",
+            "device_custom_metadata": "not an object",
+        }
+    )
+
+    assert isinstance(event, AccessCodeCreatedEvent)
+    assert event.access_code_id == "a"
+    assert event.device_custom_metadata == "not an object"
+
+
+def test_an_unknown_action_attempt_status_stays_readable():
+    attempt = action_attempt_from_dict(
+        {"action_attempt_id": "aa", "action_type": "LOCK_DOOR", "status": "cancelled"}
+    )
+
+    assert isinstance(attempt, DeepAttrDict)
+    assert attempt.status == "cancelled"
+
+
+def test_a_discriminator_that_is_not_a_string_does_not_match_a_variant():
+    event = seam_event_from_dict({"event_id": "e", "event_type": 42})
+
+    assert isinstance(event, DeepAttrDict)
+
+
+def test_waiting_on_an_unknown_status_raises_rather_than_claiming_success():
+    """An unrecognized status supports neither conclusion the wait can return.
+
+    Reporting success would tell the caller the action completed when the SDK
+    cannot tell; polling on would block until the timeout and then report a
+    timeout that misdescribes what happened.
+    """
+
+    attempt = action_attempt_from_dict(
+        {"action_attempt_id": "aa", "action_type": "LOCK_DOOR", "status": "cancelled"}
+    )
+
+    try:
+        poll_until_ready(None, action_attempt_id="aa", action_attempt=attempt)
+    except SeamActionAttemptUnknownStatusError as error:
+        assert error.status == "cancelled"
+        assert "cancelled" in str(error)
+    else:
+        raise AssertionError("expected SeamActionAttemptUnknownStatusError")
+
+
+def test_waiting_on_an_attempt_with_no_status_does_not_raise_attribute_error():
+    attempt = action_attempt_from_dict({"action_attempt_id": "aa"})
+
+    try:
+        poll_until_ready(None, action_attempt_id="aa", action_attempt=attempt)
+    except SeamActionAttemptUnknownStatusError as error:
+        assert error.status == "None"
+    else:
+        raise AssertionError("expected SeamActionAttemptUnknownStatusError")


### PR DESCRIPTION
## Summary
This change improves the SDK's resilience when parsing API responses that contain unknown or unexpected field shapes. Rather than failing when encountering new event types, action types, or error codes added to the API between SDK releases, the SDK now gracefully degrades by using sensible defaults while preserving the raw payload data.

## Key Changes

- **New `seam/parse.py` module**: Introduces shared parsing helpers (`object_from_dict`, `object_list_from_dict`, `discriminated_list_from_dict`, `record_from_dict`, `required_object_from_dict`) that handle malformed or unexpected data shapes by degrading gracefully instead of raising exceptions.

- **Updated resource dataclasses**: All resource files now:
  - Import the new parsing helpers from `seam/parse.py`
  - Remove local `_from_discriminated_dict` implementations in favor of the shared version
  - Add defensive checks in `from_dict` methods: `if not isinstance(d, dict): d = {}`
  - Use the new helpers for nested object and list parsing

- **Enhanced error handling**: 
  - Added `SeamActionAttemptUnknownStatusError` exception for action attempts with unrecognized status values
  - Updated `action_attempts.py` to handle unknown action attempt statuses gracefully

- **Comprehensive test coverage**: Added `test/total_parsing_test.py` with tests demonstrating the resilience improvements:
  - List properties sent as scalars degrade to empty lists
  - Non-object list items are preserved verbatim
  - Unknown error codes don't break the entire resource
  - Unknown event types remain accessible via `DeepAttrDict`

## Implementation Details

The parsing helpers follow a consistent pattern:
- **`record_from_dict`**: Wraps free-form records for attribute access, passing non-dict values through unchanged
- **`object_from_dict`**: Converts dict values to typed objects, returning `None` for non-dict inputs
- **`object_list_from_dict`**: Converts list items to typed objects, filtering out non-dict items
- **`discriminated_list_from_dict`**: Handles polymorphic lists with discriminator fields, falling back to `DeepAttrDict` for unknown types
- **`required_object_from_dict`**: Like `object_from_dict` but always returns an instance (using empty dict if needed)

This ensures that a single unexpected field cannot cost the caller the entire response, while the raw payload remains available for diagnosis.

https://claude.ai/code/session_01M2kJ4nGaM8imZCVMEKjmXA