### PR TITLE
feat: add raw_json() to the event returned by webhook verification

### DIFF
--- a/codegen/layouts/partials/resource-dataclass.hbs
+++ b/codegen/layouts/partials/resource-dataclass.hbs
@@ -25,6 +25,15 @@
 {{#each properties}}
 {{../memberIndent}}{{pythonIdentifier name}}: {{type}}
 {{/each}}
+{{#if @root.hasRawJson}}
+{{#unless isNested}}
+{{memberIndent}}_raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+{{memberIndent}}def raw_json(self) -> str:
+{{memberIndent}}    """Return the payload this was parsed from, as JSON."""
+{{memberIndent}}    return json.dumps(self._raw)
+{{/unless}}
+{{/if}}
 
 {{memberIndent}}@classmethod
 {{memberIndent}}def from_dict(cls, d: Any):
@@ -37,4 +46,9 @@
 {{#each properties}}
 {{../memberIndent}}        {{pythonIdentifier name}}={{#if isRequiredObject}}_required_object_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isObject}}_object_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isDiscriminatedObjectList}}_discriminated_list_from_dict(d.get("{{name}}"), cls._{{nestedClassName}}Variants, "{{discriminator}}"){{else}}{{#if isObjectList}}_object_list_from_dict(cls.{{nestedClassName}}, d.get("{{name}}")){{else}}{{#if isDictParam}}_record_from_dict({{/if}}d.get("{{name}}", None){{#if isDictParam}}){{/if}}{{/if}}{{/if}}{{/if}}{{/if}},
 {{/each}}
+{{#if @root.hasRawJson}}
+{{#unless isNested}}
+{{memberIndent}}        _raw=d,
+{{/unless}}
+{{/if}}
 {{memberIndent}}    )

--- a/codegen/layouts/resource.hbs
+++ b/codegen/layouts/resource.hbs
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List, Literal, Optional, {{#if union.secondaryDiscriminator}}Tuple, {{/if}}Union{{#if union}}, cast{{/if}}
-from dataclasses import dataclass
+from dataclasses import dataclass{{#if hasRawJson}}, field{{/if}}
+{{#if hasRawJson}}
+import json
+{{/if}}
 from ..deep_attr_dict import DeepAttrDict
 from ..parse import (
     discriminated_list_from_dict as _discriminated_list_from_dict,

--- a/codegen/lib/layouts/resources.ts
+++ b/codegen/lib/layouts/resources.ts
@@ -18,6 +18,7 @@ import {
 
 export interface ResourceLayoutContext {
   className: string
+  hasRawJson?: boolean
   moduleName: string
   isDeprecated: boolean
   deprecationMessage: string
@@ -703,8 +704,10 @@ export const getResourceLayoutContexts = (
   const eventModel = blueprint.resources.find(
     ({ resourceType }) => resourceType === 'event',
   )
-  resources.push(
-    buildUnionResource(
+  resources.push({
+    // raw_json exists for the webhook verify return, so the events carry it and
+    // nothing else does.
+    ...buildUnionResource(
       'SeamEvent',
       'event_type',
       'seam_event_from_dict',
@@ -718,7 +721,8 @@ export const getResourceLayoutContexts = (
       eventModel?.isDeprecated ?? false,
       eventModel?.deprecationMessage ?? '',
     ),
-  )
+    hasRawJson: true,
+  })
 
   const actionAttemptModel = blueprint.resources.find(
     ({ resourceType }) => resourceType === 'action_attempt',

--- a/seam/deep_attr_dict.py
+++ b/seam/deep_attr_dict.py
@@ -1,3 +1,6 @@
+import json
+
+
 class DeepAttrDict(dict):
     """A dict whose keys are also readable as attributes, nested dicts included.
 
@@ -14,6 +17,10 @@ class DeepAttrDict(dict):
                 self.__setitem__(key, value[key])
         else:
             raise TypeError("expected dict")
+
+    def raw_json(self):
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self)
 
     def __setitem__(self, key, value):
         if isinstance(value, dict) and not isinstance(value, DeepAttrDict):

--- a/seam/resources/seam_event.py
+++ b/seam/resources/seam_event.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union, cast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import json
 from ..deep_attr_dict import DeepAttrDict
 from ..parse import (
     discriminated_list_from_dict as _discriminated_list_from_dict,
@@ -48,6 +49,11 @@ class AccessCodeCreatedEvent:
     event_type: Literal["access_code.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -69,6 +75,7 @@ class AccessCodeCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -139,6 +146,11 @@ class AccessCodeChangedEvent:
     event_type: Literal["access_code.changed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -164,6 +176,7 @@ class AccessCodeChangedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -245,6 +258,11 @@ class AccessCodeNameChangedEvent:
     occurred_at: str
     to: Optional[To]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -269,6 +287,7 @@ class AccessCodeNameChangedEvent:
             occurred_at=d.get("occurred_at", None),
             to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -350,6 +369,11 @@ class AccessCodeCodeChangedEvent:
     occurred_at: str
     to: Optional[To]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -374,6 +398,7 @@ class AccessCodeCodeChangedEvent:
             occurred_at=d.get("occurred_at", None),
             to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -463,6 +488,11 @@ class AccessCodeTimeFrameChangedEvent:
     occurred_at: str
     to: Optional[To]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -487,6 +517,7 @@ class AccessCodeTimeFrameChangedEvent:
             occurred_at=d.get("occurred_at", None),
             to=_object_from_dict(cls.To, d.get("to")),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -562,6 +593,11 @@ class AccessCodeMutationsRequestedEvent:
     occurred_at: str
     requested_mutations: List[RequestedMutations]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -586,6 +622,7 @@ class AccessCodeMutationsRequestedEvent:
                 cls.RequestedMutations, d.get("requested_mutations")
             ),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -629,6 +666,11 @@ class AccessCodeScheduledOnDeviceEvent:
     event_type: Literal["access_code.scheduled_on_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -651,6 +693,7 @@ class AccessCodeScheduledOnDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -694,6 +737,11 @@ class AccessCodeSetOnDeviceEvent:
     event_type: Literal["access_code.set_on_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -716,6 +764,7 @@ class AccessCodeSetOnDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -756,6 +805,11 @@ class AccessCodeRemovedFromDeviceEvent:
     event_type: Literal["access_code.removed_from_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -777,6 +831,7 @@ class AccessCodeRemovedFromDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -985,6 +1040,11 @@ class AccessCodeDelayInSettingOnDeviceEvent:
     event_type: Literal["access_code.delay_in_setting_on_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1024,6 +1084,7 @@ class AccessCodeDelayInSettingOnDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1232,6 +1293,11 @@ class AccessCodeFailedToSetOnDeviceEvent:
     event_type: Literal["access_code.failed_to_set_on_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1271,6 +1337,7 @@ class AccessCodeFailedToSetOnDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1314,6 +1381,11 @@ class AccessCodeDeletedEvent:
     event_type: Literal["access_code.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1336,6 +1408,7 @@ class AccessCodeDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1548,6 +1621,11 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
     event_type: Literal["access_code.delay_in_removing_from_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1587,6 +1665,7 @@ class AccessCodeDelayInRemovingFromDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1795,6 +1874,11 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
     event_type: Literal["access_code.failed_to_remove_from_device"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1834,6 +1918,7 @@ class AccessCodeFailedToRemoveFromDeviceEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1874,6 +1959,11 @@ class AccessCodeModifiedExternalToSeamEvent:
     event_type: Literal["access_code.modified_external_to_seam"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1895,6 +1985,7 @@ class AccessCodeModifiedExternalToSeamEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1935,6 +2026,11 @@ class AccessCodeDeletedExternalToSeamEvent:
     event_type: Literal["access_code.deleted_external_to_seam"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -1956,6 +2052,7 @@ class AccessCodeDeletedExternalToSeamEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -1999,6 +2096,11 @@ class AccessCodeBackupAccessCodePulledEvent:
     event_type: Literal["access_code.backup_access_code_pulled"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2021,6 +2123,7 @@ class AccessCodeBackupAccessCodePulledEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2061,6 +2164,11 @@ class AccessCodeUnmanagedConvertedToManagedEvent:
     event_type: Literal["access_code.unmanaged.converted_to_managed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2082,6 +2190,7 @@ class AccessCodeUnmanagedConvertedToManagedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2290,6 +2399,11 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
     event_type: Literal["access_code.unmanaged.failed_to_convert_to_managed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2329,6 +2443,7 @@ class AccessCodeUnmanagedFailedToConvertToManagedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2369,6 +2484,11 @@ class AccessCodeUnmanagedCreatedEvent:
     event_type: Literal["access_code.unmanaged.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2390,6 +2510,7 @@ class AccessCodeUnmanagedCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2430,6 +2551,11 @@ class AccessCodeUnmanagedRemovedEvent:
     event_type: Literal["access_code.unmanaged.removed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2451,6 +2577,7 @@ class AccessCodeUnmanagedRemovedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2479,6 +2606,11 @@ class AccessGrantCreatedEvent:
     event_type: Literal["access_grant.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2492,6 +2624,7 @@ class AccessGrantCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2520,6 +2653,11 @@ class AccessGrantDeletedEvent:
     event_type: Literal["access_grant.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2533,6 +2671,7 @@ class AccessGrantDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2561,6 +2700,11 @@ class AccessGrantAccessGrantedToAllDoorsEvent:
     event_type: Literal["access_grant.access_granted_to_all_doors"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2574,6 +2718,7 @@ class AccessGrantAccessGrantedToAllDoorsEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2605,6 +2750,11 @@ class AccessGrantAccessGrantedToDoorEvent:
     event_type: Literal["access_grant.access_granted_to_door"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2619,6 +2769,7 @@ class AccessGrantAccessGrantedToDoorEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2650,6 +2801,11 @@ class AccessGrantAccessToDoorLostEvent:
     event_type: Literal["access_grant.access_to_door_lost"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2664,6 +2820,7 @@ class AccessGrantAccessToDoorLostEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2701,6 +2858,11 @@ class AccessGrantAccessTimesChangedEvent:
     occurred_at: str
     starts_at: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2717,6 +2879,7 @@ class AccessGrantAccessTimesChangedEvent:
             occurred_at=d.get("occurred_at", None),
             starts_at=d.get("starts_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2751,6 +2914,11 @@ class AccessGrantCouldNotCreateRequestedAccessMethodsEvent:
     missing_device_ids: Optional[List[str]]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2766,6 +2934,7 @@ class AccessGrantCouldNotCreateRequestedAccessMethodsEvent:
             missing_device_ids=d.get("missing_device_ids", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2806,6 +2975,11 @@ class AccessMethodIssuedEvent:
     is_backup_code: Optional[bool]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2823,6 +2997,7 @@ class AccessMethodIssuedEvent:
             is_backup_code=d.get("is_backup_code", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2857,6 +3032,11 @@ class AccessMethodRevokedEvent:
     event_type: Literal["access_method.revoked"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2872,6 +3052,7 @@ class AccessMethodRevokedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2906,6 +3087,11 @@ class AccessMethodCardEncodingRequiredEvent:
     event_type: Literal["access_method.card_encoding_required"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2921,6 +3107,7 @@ class AccessMethodCardEncodingRequiredEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -2955,6 +3142,11 @@ class AccessMethodDeletedEvent:
     event_type: Literal["access_method.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -2970,6 +3162,7 @@ class AccessMethodDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3010,6 +3203,11 @@ class AccessMethodReissuedEvent:
     is_backup_code: Optional[bool]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3027,6 +3225,7 @@ class AccessMethodReissuedEvent:
             is_backup_code=d.get("is_backup_code", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3061,6 +3260,11 @@ class AccessMethodCreatedEvent:
     event_type: Literal["access_method.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3076,6 +3280,7 @@ class AccessMethodCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3110,6 +3315,11 @@ class AccessMethodDelayInIssuingEvent:
     event_type: Literal["access_method.delay_in_issuing"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3125,6 +3335,7 @@ class AccessMethodDelayInIssuingEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3159,6 +3370,11 @@ class AccessMethodFailedToIssueEvent:
     event_type: Literal["access_method.failed_to_issue"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3174,6 +3390,7 @@ class AccessMethodFailedToIssueEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3205,6 +3422,11 @@ class AcsSystemConnectedEvent:
     event_type: Literal["acs_system.connected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3219,6 +3441,7 @@ class AcsSystemConnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3250,6 +3473,11 @@ class AcsSystemAddedEvent:
     event_type: Literal["acs_system.added"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3264,6 +3492,7 @@ class AcsSystemAddedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3407,6 +3636,11 @@ class AcsSystemDisconnectedEvent:
     event_type: Literal["acs_system.disconnected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3433,6 +3667,7 @@ class AcsSystemDisconnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3467,6 +3702,11 @@ class AcsCredentialDeletedEvent:
     event_type: Literal["acs_credential.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3482,6 +3722,7 @@ class AcsCredentialDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3516,6 +3757,11 @@ class AcsCredentialIssuedEvent:
     event_type: Literal["acs_credential.issued"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3531,6 +3777,7 @@ class AcsCredentialIssuedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3565,6 +3812,11 @@ class AcsCredentialReissuedEvent:
     event_type: Literal["acs_credential.reissued"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3580,6 +3832,7 @@ class AcsCredentialReissuedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3614,6 +3867,11 @@ class AcsCredentialInvalidatedEvent:
     event_type: Literal["acs_credential.invalidated"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3629,6 +3887,7 @@ class AcsCredentialInvalidatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3663,6 +3922,11 @@ class AcsUserCreatedEvent:
     event_type: Literal["acs_user.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3678,6 +3942,7 @@ class AcsUserCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3712,6 +3977,11 @@ class AcsUserDeletedEvent:
     event_type: Literal["acs_user.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3727,6 +3997,7 @@ class AcsUserDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3761,6 +4032,11 @@ class AcsEncoderAddedEvent:
     event_type: Literal["acs_encoder.added"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3776,6 +4052,7 @@ class AcsEncoderAddedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3810,6 +4087,11 @@ class AcsEncoderRemovedEvent:
     event_type: Literal["acs_encoder.removed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3825,6 +4107,7 @@ class AcsEncoderRemovedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3859,6 +4142,11 @@ class AcsAccessGroupDeletedEvent:
     event_type: Literal["acs_access_group.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3874,6 +4162,7 @@ class AcsAccessGroupDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3908,6 +4197,11 @@ class AcsEntranceAddedEvent:
     event_type: Literal["acs_entrance.added"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3923,6 +4217,7 @@ class AcsEntranceAddedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -3957,6 +4252,11 @@ class AcsEntranceRemovedEvent:
     event_type: Literal["acs_entrance.removed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -3972,6 +4272,7 @@ class AcsEntranceRemovedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4000,6 +4301,11 @@ class ClientSessionDeletedEvent:
     event_type: Literal["client_session.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4013,6 +4319,7 @@ class ClientSessionDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4050,6 +4357,11 @@ class ConnectedAccountConnectedEvent:
     event_type: Literal["connected_account.connected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4068,6 +4380,7 @@ class ConnectedAccountConnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4102,6 +4415,11 @@ class ConnectedAccountCreatedEvent:
     event_type: Literal["connected_account.created"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4119,6 +4437,7 @@ class ConnectedAccountCreatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4156,6 +4475,11 @@ class ConnectedAccountSuccessfulLoginEvent:
     event_type: Literal["connected_account.successful_login"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4173,6 +4497,7 @@ class ConnectedAccountSuccessfulLoginEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4260,6 +4585,11 @@ class ConnectedAccountDisconnectedEvent:
     event_type: Literal["connected_account.disconnected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4282,6 +4612,7 @@ class ConnectedAccountDisconnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4313,6 +4644,11 @@ class ConnectedAccountCompletedFirstSyncEvent:
     event_type: Literal["connected_account.completed_first_sync"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4329,6 +4665,7 @@ class ConnectedAccountCompletedFirstSyncEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4363,6 +4700,11 @@ class ConnectedAccountDeletedEvent:
     event_type: Literal["connected_account.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4380,6 +4722,7 @@ class ConnectedAccountDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4411,6 +4754,11 @@ class ConnectedAccountCompletedFirstSyncAfterReconnectionEvent:
     event_type: Literal["connected_account.completed_first_sync_after_reconnection"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4427,6 +4775,7 @@ class ConnectedAccountCompletedFirstSyncAfterReconnectionEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4514,6 +4863,11 @@ class ConnectedAccountReauthorizationRequestedEvent:
     event_type: Literal["connected_account.reauthorization_requested"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4536,6 +4890,7 @@ class ConnectedAccountReauthorizationRequestedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4576,6 +4931,11 @@ class ActionAttemptLockDoorSucceededEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4593,6 +4953,7 @@ class ActionAttemptLockDoorSucceededEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4633,6 +4994,11 @@ class ActionAttemptLockDoorFailedEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4650,6 +5016,7 @@ class ActionAttemptLockDoorFailedEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4690,6 +5057,11 @@ class ActionAttemptUnlockDoorSucceededEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4707,6 +5079,7 @@ class ActionAttemptUnlockDoorSucceededEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4747,6 +5120,11 @@ class ActionAttemptUnlockDoorFailedEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4764,6 +5142,7 @@ class ActionAttemptUnlockDoorFailedEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4804,6 +5183,11 @@ class ActionAttemptSimulateKeypadCodeEntrySucceededEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4821,6 +5205,7 @@ class ActionAttemptSimulateKeypadCodeEntrySucceededEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4861,6 +5246,11 @@ class ActionAttemptSimulateKeypadCodeEntryFailedEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4878,6 +5268,7 @@ class ActionAttemptSimulateKeypadCodeEntryFailedEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4918,6 +5309,11 @@ class ActionAttemptSimulateManualLockViaKeypadSucceededEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4935,6 +5331,7 @@ class ActionAttemptSimulateManualLockViaKeypadSucceededEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -4975,6 +5372,11 @@ class ActionAttemptSimulateManualLockViaKeypadFailedEvent:
     occurred_at: str
     status: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -4992,6 +5394,7 @@ class ActionAttemptSimulateManualLockViaKeypadFailedEvent:
             occurred_at=d.get("occurred_at", None),
             status=d.get("status", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5029,6 +5432,11 @@ class ConnectWebviewLoginSucceededEvent:
     event_type: Literal["connect_webview.login_succeeded"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5047,6 +5455,7 @@ class ConnectWebviewLoginSucceededEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5075,6 +5484,11 @@ class ConnectWebviewLoginFailedEvent:
     event_type: Literal["connect_webview.login_failed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5088,6 +5502,7 @@ class ConnectWebviewLoginFailedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5128,6 +5543,11 @@ class DeviceConnectedEvent:
     event_type: Literal["device.connected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5149,6 +5569,7 @@ class DeviceConnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5189,6 +5610,11 @@ class DeviceAddedEvent:
     event_type: Literal["device.added"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5210,6 +5636,7 @@ class DeviceAddedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5250,6 +5677,11 @@ class DeviceConvertedToUnmanagedEvent:
     event_type: Literal["device.converted_to_unmanaged"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5271,6 +5703,7 @@ class DeviceConvertedToUnmanagedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5311,6 +5744,11 @@ class DeviceUnmanagedConvertedToManagedEvent:
     event_type: Literal["device.unmanaged.converted_to_managed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5332,6 +5770,7 @@ class DeviceUnmanagedConvertedToManagedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5372,6 +5811,11 @@ class DeviceUnmanagedConnectedEvent:
     event_type: Literal["device.unmanaged.connected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5393,6 +5837,7 @@ class DeviceUnmanagedConnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5550,6 +5995,11 @@ class DeviceDisconnectedEvent:
     event_type: Literal["device.disconnected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5584,6 +6034,7 @@ class DeviceDisconnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5741,6 +6192,11 @@ class DeviceUnmanagedDisconnectedEvent:
     event_type: Literal["device.unmanaged.disconnected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5775,6 +6231,7 @@ class DeviceUnmanagedDisconnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5815,6 +6272,11 @@ class DeviceTamperedEvent:
     event_type: Literal["device.tampered"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5836,6 +6298,7 @@ class DeviceTamperedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5885,6 +6348,11 @@ class DeviceLowBatteryEvent:
     event_type: Literal["device.low_battery"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5911,6 +6379,7 @@ class DeviceLowBatteryEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -5957,6 +6426,11 @@ class DeviceBatteryStatusChangedEvent:
     event_type: Literal["device.battery_status_changed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -5980,6 +6454,7 @@ class DeviceBatteryStatusChangedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6020,6 +6495,11 @@ class DeviceRemovedEvent:
     event_type: Literal["device.removed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6041,6 +6521,7 @@ class DeviceRemovedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6084,6 +6565,11 @@ class DeviceDeletedEvent:
     event_type: Literal["device.deleted"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6106,6 +6592,7 @@ class DeviceDeletedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6146,6 +6633,11 @@ class DeviceThirdPartyIntegrationDetectedEvent:
     event_type: Literal["device.third_party_integration_detected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6167,6 +6659,7 @@ class DeviceThirdPartyIntegrationDetectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6207,6 +6700,11 @@ class DeviceThirdPartyIntegrationNoLongerDetectedEvent:
     event_type: Literal["device.third_party_integration_no_longer_detected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6228,6 +6726,7 @@ class DeviceThirdPartyIntegrationNoLongerDetectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6268,6 +6767,11 @@ class DeviceSaltoPrivacyModeActivatedEvent:
     event_type: Literal["device.salto.privacy_mode_activated"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6289,6 +6793,7 @@ class DeviceSaltoPrivacyModeActivatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6329,6 +6834,11 @@ class DeviceSaltoPrivacyModeDeactivatedEvent:
     event_type: Literal["device.salto.privacy_mode_deactivated"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6350,6 +6860,7 @@ class DeviceSaltoPrivacyModeDeactivatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6502,6 +7013,11 @@ class DeviceConnectionBecameFlakyEvent:
     event_type: Literal["device.connection_became_flaky"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6535,6 +7051,7 @@ class DeviceConnectionBecameFlakyEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6575,6 +7092,11 @@ class DeviceConnectionStabilizedEvent:
     event_type: Literal["device.connection_stabilized"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6596,6 +7118,7 @@ class DeviceConnectionStabilizedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6748,6 +7271,11 @@ class DeviceErrorSubscriptionRequiredEvent:
     event_type: Literal["device.error.subscription_required"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6781,6 +7309,7 @@ class DeviceErrorSubscriptionRequiredEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6821,6 +7350,11 @@ class DeviceErrorSubscriptionRequiredResolvedEvent:
     event_type: Literal["device.error.subscription_required.resolved"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6842,6 +7376,7 @@ class DeviceErrorSubscriptionRequiredResolvedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -6882,6 +7417,11 @@ class DeviceAccessoryKeypadConnectedEvent:
     event_type: Literal["device.accessory_keypad_connected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -6903,6 +7443,7 @@ class DeviceAccessoryKeypadConnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7055,6 +7596,11 @@ class DeviceAccessoryKeypadDisconnectedEvent:
     event_type: Literal["device.accessory_keypad_disconnected"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7088,6 +7634,7 @@ class DeviceAccessoryKeypadDisconnectedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7146,6 +7693,11 @@ class NoiseSensorNoiseThresholdTriggeredEvent:
     noiseaware_metadata: Optional[Dict[str, Any]]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7173,6 +7725,7 @@ class NoiseSensorNoiseThresholdTriggeredEvent:
             noiseaware_metadata=_record_from_dict(d.get("noiseaware_metadata", None)),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7234,6 +7787,11 @@ class LockLockedEvent:
     method: Literal["keycode", "manual", "automatic", "unknown", "remote", "card"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7262,6 +7820,7 @@ class LockLockedEvent:
             method=d.get("method", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7323,6 +7882,11 @@ class LockUnlockedEvent:
     method: Literal["keycode", "manual", "automatic", "unknown", "remote", "card"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7351,6 +7915,7 @@ class LockUnlockedEvent:
             method=d.get("method", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7425,6 +7990,11 @@ class LockAccessDeniedEvent:
     occurred_at: str
     reason: Optional[Reason]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7448,6 +8018,7 @@ class LockAccessDeniedEvent:
             occurred_at=d.get("occurred_at", None),
             reason=_object_from_dict(cls.Reason, d.get("reason")),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7497,6 +8068,11 @@ class ThermostatClimatePresetActivatedEvent:
     occurred_at: str
     thermostat_schedule_id: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7521,6 +8097,7 @@ class ThermostatClimatePresetActivatedEvent:
             occurred_at=d.get("occurred_at", None),
             thermostat_schedule_id=d.get("thermostat_schedule_id", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7582,6 +8159,11 @@ class ThermostatManuallyAdjustedEvent:
     method: Literal["seam", "external"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7610,6 +8192,7 @@ class ThermostatManuallyAdjustedEvent:
             method=d.get("method", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7668,6 +8251,11 @@ class ThermostatTemperatureThresholdExceededEvent:
     upper_limit_celsius: Optional[float]
     upper_limit_fahrenheit: Optional[float]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7695,6 +8283,7 @@ class ThermostatTemperatureThresholdExceededEvent:
             upper_limit_celsius=d.get("upper_limit_celsius", None),
             upper_limit_fahrenheit=d.get("upper_limit_fahrenheit", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7753,6 +8342,11 @@ class ThermostatTemperatureThresholdNoLongerExceededEvent:
     upper_limit_celsius: Optional[float]
     upper_limit_fahrenheit: Optional[float]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7780,6 +8374,7 @@ class ThermostatTemperatureThresholdNoLongerExceededEvent:
             upper_limit_celsius=d.get("upper_limit_celsius", None),
             upper_limit_fahrenheit=d.get("upper_limit_fahrenheit", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7832,6 +8427,11 @@ class ThermostatTemperatureReachedSetPointEvent:
     temperature_celsius: float
     temperature_fahrenheit: float
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7859,6 +8459,7 @@ class ThermostatTemperatureReachedSetPointEvent:
             temperature_celsius=d.get("temperature_celsius", None),
             temperature_fahrenheit=d.get("temperature_fahrenheit", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7905,6 +8506,11 @@ class ThermostatTemperatureChangedEvent:
     temperature_celsius: float
     temperature_fahrenheit: float
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7928,6 +8534,7 @@ class ThermostatTemperatureChangedEvent:
             temperature_celsius=d.get("temperature_celsius", None),
             temperature_fahrenheit=d.get("temperature_fahrenheit", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -7971,6 +8578,11 @@ class DeviceNameChangedEvent:
     event_type: Literal["device.name_changed"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -7993,6 +8605,7 @@ class DeviceNameChangedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8045,6 +8658,11 @@ class CameraActivatedEvent:
     occurred_at: str
     video_url: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8070,6 +8688,7 @@ class CameraActivatedEvent:
             occurred_at=d.get("occurred_at", None),
             video_url=d.get("video_url", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8116,6 +8735,11 @@ class DeviceDoorbellRangEvent:
     occurred_at: str
     video_url: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8139,6 +8763,7 @@ class DeviceDoorbellRangEvent:
             occurred_at=d.get("occurred_at", None),
             video_url=d.get("video_url", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8170,6 +8795,11 @@ class PhoneDeactivatedEvent:
     event_type: Literal["phone.deactivated"]
     occurred_at: str
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8186,6 +8816,7 @@ class PhoneDeactivatedEvent:
             event_type=d.get("event_type", None),
             occurred_at=d.get("occurred_at", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8223,6 +8854,11 @@ class SpaceDeviceMembershipChangedEvent:
     space_id: str
     space_key: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8239,6 +8875,7 @@ class SpaceDeviceMembershipChangedEvent:
             space_id=d.get("space_id", None),
             space_key=d.get("space_key", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8276,6 +8913,11 @@ class SpaceCreatedEvent:
     space_id: str
     space_key: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8292,6 +8934,7 @@ class SpaceCreatedEvent:
             space_id=d.get("space_id", None),
             space_key=d.get("space_key", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 
@@ -8329,6 +8972,11 @@ class SpaceDeletedEvent:
     space_id: str
     space_key: Optional[str]
     workspace_id: str
+    _raw: Optional[Dict[str, Any]] = field(default=None, repr=False, compare=False)
+
+    def raw_json(self) -> str:
+        """Return the payload this was parsed from, as JSON."""
+        return json.dumps(self._raw)
 
     @classmethod
     def from_dict(cls, d: Any):
@@ -8345,6 +8993,7 @@ class SpaceDeletedEvent:
             space_id=d.get("space_id", None),
             space_key=d.get("space_key", None),
             workspace_id=d.get("workspace_id", None),
+            _raw=d,
         )
 
 

--- a/test/total_parsing_test.py
+++ b/test/total_parsing_test.py
@@ -1,5 +1,7 @@
 """Regression tests for reading responses that do not match the generated shape."""
 
+import json
+
 from seam.deep_attr_dict import DeepAttrDict
 from seam.exceptions import SeamActionAttemptUnknownStatusError
 from seam.modules.action_attempts import poll_until_ready
@@ -115,3 +117,45 @@ def test_waiting_on_an_attempt_with_no_status_does_not_raise_attribute_error():
         assert error.status == "None"
     else:
         raise AssertionError("expected SeamActionAttemptUnknownStatusError")
+
+
+def test_raw_json_recovers_a_field_the_generated_shape_drops():
+    payload = {
+        "event_id": "event_1",
+        "event_type": "access_code.created",
+        "brand_new_field": "kept",
+    }
+
+    event = seam_event_from_dict(payload)
+
+    assert not hasattr(event, "brand_new_field")
+    assert json.loads(event.raw_json()) == payload
+
+
+def test_raw_json_round_trips_an_unrecognized_event():
+    payload = {"event_id": "event_1", "event_type": "future.thing", "nested": {"x": 1}}
+
+    assert json.loads(seam_event_from_dict(payload).raw_json()) == payload
+
+
+def test_raw_json_is_absent_from_the_event_repr():
+    event = seam_event_from_dict(
+        {"event_id": "event_1", "event_type": "access_code.created"}
+    )
+
+    assert "_raw" not in repr(event)
+
+
+def test_two_events_with_the_same_fields_compare_equal():
+    # The retained payload must not make otherwise-identical events unequal.
+    a = seam_event_from_dict(
+        {"event_id": "e", "event_type": "access_code.created", "extra": 1}
+    )
+    b = seam_event_from_dict({"event_id": "e", "event_type": "access_code.created"})
+
+    assert a == b
+
+
+def test_raw_json_is_scoped_to_events():
+    # It exists for the webhook verify return, not as a general model accessor.
+    assert not hasattr(Device.from_dict({"device_id": "device_1"}), "raw_json")


### PR DESCRIPTION
Follow-up to #651. That PR made parsing degrade instead of raise, but it did not keep the payload — so this is the half that actually lets a handler reach something the SDK does not know about yet.

## The gap

`from_dict` reads only the properties it was generated for, so a field Seam adds to an existing event between SDK releases is silently discarded:

```python
Device.from_dict({'device_id': 'd', 'brand_new_field': 'kept?'})
# brand_new_field: <<DROPPED>>
```

There was no way to recover it short of upgrading the SDK.

## The change

`SeamWebhook.verify()` now returns an event carrying `raw_json()`:

```python
event = webhook.verify(payload, headers)
json.loads(event.raw_json())["a_field_this_version_predates"]
```

`DeepAttrDict` answers the same call, so the unrecognized-event branch and the typed branch are handled the same way. That matters more than it first appears: the fallback is not otherwise interchangeable with a generated event, because reading a missing key raises `AttributeError` where a dataclass returns `None`. Generic code written against the declared union breaks on it:

```python
def log_any_event(ev):
    return f'{ev.event_type} in {ev.workspace_id}'

log_any_event(known_event)        # 'device.connected in w'
log_any_event(unrecognized_event) # AttributeError: workspace_id
```

`raw_json()` gives both branches one thing that always works.

## Scope

Events only. It exists for the `verify` return, not as a general accessor on every model — `Device`, action attempts and the rest are untouched, and there is a test pinning that.

A method rather than a property because the call is where the serialization happens: the event retains the decoded payload and serializes on demand. The retained payload is `repr=False` and `compare=False`, so it changes neither the repr nor equality.

## Verification

`just lint && just test` — 289 tests, mypy clean, pylint 10.00/10, black clean.

New tests cover recovering a dropped field, round-tripping a known and an unrecognized event, absence from the repr, equality being unaffected, and `raw_json` not leaking onto non-event models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2kJ4nGaM8imZCVMEKjmXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2kJ4nGaM8imZCVMEKjmXA)_